### PR TITLE
feat: parse uploaded screenshot into contribution grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Open http://localhost:3000
 - 3D heatmap with react-three-fiber.
 - Web Audio engine (oscillator-based) with Play/Pause/Seek and hover preview.
 - ±15s skip, BPM control, Scale/Key selection.
-- Screenshot upload stub (UI; parsing/color-bucketing can be added later).
+- Screenshot upload parses GitHub heatmap screenshots into a 7×53 contribution grid.
 
 ## Folders
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -180,8 +180,15 @@ export default function Page() {
       {tab === "upload" && (
         <section className="flex flex-col gap-3">
           <Uploader
-            onImageLoaded={(f) => {
-              /* future: parse screenshot */
+            onGridLoaded={(g) => {
+              const mapped = mapGridToMusic(g, { bpm });
+              setGrid(mapped);
+              const e = engineRef.current!;
+              e.setBpm(bpm);
+              e.attachGrid(mapped);
+              e.prepareScheduleFromGrid();
+              setPos(0);
+              setPlaying(false);
             }}
           />
         </section>

--- a/components/Uploader.tsx
+++ b/components/Uploader.tsx
@@ -1,14 +1,94 @@
 'use client';
 
 import React, { useRef, useState } from 'react';
+import type { Grid, GridCell } from '@/lib/types';
 
 type Props = {
-  onImageLoaded?: (file: File) => void;
+  /**
+   * Fired once the screenshot is parsed into a contribution grid.
+   */
+  onGridLoaded?: (grid: Grid) => void;
 };
 
-export default function Uploader({ onImageLoaded }: Props) {
+// GitHub contribution colors (light to dark)
+const GH_COLORS = ['#ebedf0', '#9be9a8', '#40c463', '#30a14e', '#216e39'];
+
+function hexToRgb(hex: string) {
+  const int = parseInt(hex.slice(1), 16);
+  return {
+    r: (int >> 16) & 255,
+    g: (int >> 8) & 255,
+    b: int & 255,
+  };
+}
+
+function nearestBucket(r: number, g: number, b: number) {
+  let best = 0;
+  let bestDist = Infinity;
+  for (let i = 0; i < GH_COLORS.length; i++) {
+    const c = hexToRgb(GH_COLORS[i]);
+    const d = Math.pow(c.r - r, 2) + Math.pow(c.g - g, 2) + Math.pow(c.b - b, 2);
+    if (d < bestDist) {
+      bestDist = d;
+      best = i;
+    }
+  }
+  return best;
+}
+
+function parseImage(img: HTMLImageElement): Grid {
+  const canvas = document.createElement('canvas');
+  canvas.width = img.width;
+  canvas.height = img.height;
+  const ctx = canvas.getContext('2d')!;
+  ctx.drawImage(img, 0, 0);
+
+  const rows = 7;
+  const cols = 53; // GitHub heatmap always 53 weeks
+  const cellW = img.width / cols;
+  const cellH = img.height / rows;
+
+  const cells: GridCell[] = [];
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      const x = Math.floor(col * cellW + cellW / 2);
+      const y = Math.floor(row * cellH + cellH / 2);
+      const data = ctx.getImageData(x, y, 1, 1).data;
+      const bucket = nearestBucket(data[0], data[1], data[2]);
+      cells.push({
+        date: '',
+        count: 0,
+        color: GH_COLORS[bucket],
+        intensity: bucket,
+        row,
+        col,
+        noteIndex: 0,
+        velocity: 0.5,
+        duration: 0.25,
+      });
+    }
+  }
+
+  return { rows, cols, cells };
+}
+
+export default function Uploader({ onGridLoaded }: Props) {
   const ref = useRef<HTMLInputElement>(null);
   const [name, setName] = useState<string>('');
+
+  const handleFile = (file: File) => {
+    setName(file.name);
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = () => {
+        const grid = parseImage(img);
+        onGridLoaded?.(grid);
+      };
+      img.src = reader.result as string;
+    };
+    reader.readAsDataURL(file);
+  };
 
   return (
     <div className="p-3 border border-neutral-800 rounded-md">
@@ -21,8 +101,7 @@ export default function Uploader({ onImageLoaded }: Props) {
           onChange={(e) => {
             const file = e.target.files?.[0];
             if (file) {
-              setName(file.name);
-              onImageLoaded?.(file);
+              handleFile(file);
             }
           }}
         />
@@ -35,8 +114,9 @@ export default function Uploader({ onImageLoaded }: Props) {
         <span className="opacity-70 text-sm">{name}</span>
       </div>
       <p className="text-xs opacity-70 mt-2">
-        (MVP) This upload path is a stub. Parsing/color-bucketing can be added next.
+        Parsing is naive and expects a raw GitHub contribution grid screenshot.
       </p>
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- add GitHub contribution color palette and pixel-to-bucket helpers
- parse uploaded GitHub screenshot into a 7×53 grid structure
- hook uploader to page and map parsed grid to audio engine
- document screenshot upload capability

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68ae562c06d483229afdeab4855ce4c7