### PR TITLE
Resume AudioContext before playing grid

### DIFF
--- a/lib/audio.ts
+++ b/lib/audio.ts
@@ -80,6 +80,9 @@ export class AudioEngine {
   }
 
   preview(freq: number, velocity = 0.8, duration = 0.25) {
+    if (this.ctx.state === 'suspended') {
+      this.ctx.resume();
+    }
     const t = this.ctx.currentTime + 0.01;
     this.playVoice(t, freq, duration, velocity);
   }
@@ -110,6 +113,10 @@ export class AudioEngine {
   play() {
     if (!this.grid) return;
     if (!this.scheduled.length) this.prepareScheduleFromGrid();
+
+    if (this.ctx.state === 'suspended') {
+      this.ctx.resume();
+    }
 
     this.playing = true;
     this.startTime = this.ctx.currentTime;


### PR DESCRIPTION
## Summary
- resume suspended AudioContext when previewing or playing notes

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive ESLint setup)


------
https://chatgpt.com/codex/tasks/task_e_68ae65203d608322867da8f7ebc2d30c