### PR TITLE
feat: add contribution tooltip

### DIFF
--- a/app/PointerTracker.tsx
+++ b/app/PointerTracker.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useHoverStore } from '@/lib/hoverStore';
+
+export function PointerTracker() {
+  const setCursor = useHoverStore((s) => s.setCursor);
+
+  useEffect(() => {
+    const h = (e: MouseEvent) => setCursor({ x: e.clientX, y: e.clientY });
+    window.addEventListener('mousemove', h, { passive: true });
+    return () => window.removeEventListener('mousemove', h);
+  }, [setCursor]);
+
+  return null;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,8 @@ import { GridScene } from "@/components/Grid3D";
 import Transport from "@/components/Transport";
 import Uploader from "@/components/Uploader";
 import { InstrumentSelect } from "@/components/InstrumentSelect";
+import { HeatmapTooltip } from "@/components/HeatmapTooltip";
+import { PointerTracker } from "./PointerTracker";
 import { fetchContributionGrid } from "@/lib/contrib";
 import { mapGridToMusic } from "@/lib/mapping";
 import type { Grid, GridCell } from "@/lib/types";
@@ -130,7 +132,10 @@ export default function Page() {
   };
 
   return (
-    <main className="max-w-6xl mx-auto p-4 flex flex-col gap-4">
+    <>
+      <PointerTracker />
+      <HeatmapTooltip />
+      <main className="max-w-6xl mx-auto p-4 flex flex-col gap-4">
       <header className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3">
         <div>
           <h1 className="text-2xl font-semibold">ContriSonics</h1>
@@ -245,6 +250,7 @@ export default function Page() {
       <footer className="opacity-60 text-xs">
         Built with Next.js, react-three-fiber, and the Web Audio API. © Natsuki.
       </footer>
-    </main>
+      </main>
+    </>
   );
 }

--- a/components/Grid3D.tsx
+++ b/components/Grid3D.tsx
@@ -1,42 +1,15 @@
 'use client';
 
-import React, { useMemo, useRef } from 'react';
-import { Canvas, ThreeEvent } from '@react-three/fiber';
+import React, { useMemo } from 'react';
+import { Canvas } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
-import * as THREE from 'three';
 import type { Grid, GridCell } from '@/lib/types';
+import { GridCell3D } from './GridCell3D';
 
 type Props = {
   grid: Grid | null;
   onHoverNote?: (cell: GridCell) => void;
 };
-
-function CellBox({ cell, onHoverNote }: { cell: GridCell, onHoverNote?: (c: GridCell)=>void }) {
-  const meshRef = useRef<THREE.Mesh>(null!);
-  const height = 0.2 + (cell.intensity * 0.35);
-  const color = new THREE.Color(cell.color || '#2ea043');
-  const emissive = color.clone().multiplyScalar(0.25 + cell.intensity * 0.15);
-  const posX = cell.col * 0.9;
-  const posZ = cell.row * 0.9;
-
-  const onPointerOver = (e: ThreeEvent<PointerEvent>) => {
-    e.stopPropagation();
-    onHoverNote?.(cell);
-  };
-
-  return (
-    <mesh
-      ref={meshRef}
-      position={[posX, height/2, posZ]}
-      onPointerOver={onPointerOver}
-      castShadow
-      receiveShadow
-    >
-      <boxGeometry args={[0.8, height, 0.8]} />
-      <meshStandardMaterial color={color} emissive={emissive} />
-    </mesh>
-  );
-}
 
 export function GridScene({ grid, onHoverNote }: Props) {
   const size = useMemo(() => ({
@@ -54,7 +27,7 @@ export function GridScene({ grid, onHoverNote }: Props) {
           <meshStandardMaterial color={'#111214'} />
         </mesh>
         {grid?.cells.map((c, i) => (
-          <CellBox key={i} cell={c} onHoverNote={onHoverNote} />
+          <GridCell3D key={i} cell={c} onHoverNote={onHoverNote} />
         ))}
       </group>
       <OrbitControls enablePan={false} minPolarAngle={Math.PI/4} maxPolarAngle={Math.PI/3} />

--- a/components/GridCell3D.tsx
+++ b/components/GridCell3D.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useRef } from 'react';
+import { Mesh, Vector3 } from 'three';
+import * as THREE from 'three';
+import { ThreeEvent, useThree } from '@react-three/fiber';
+import { useHoverStore } from '@/lib/hoverStore';
+import type { GridCell } from '@/lib/types';
+
+type Props = {
+  cell: GridCell;
+  onHoverNote?: (cell: GridCell) => void;
+};
+
+export function GridCell3D({ cell, onHoverNote }: Props) {
+  const ref = useRef<Mesh>(null!);
+  const setHovered = useHoverStore((s) => s.setHovered);
+  const setCursor = useHoverStore((s) => s.setCursor);
+  const { camera, size } = useThree();
+
+  const height = 0.2 + cell.intensity * 0.35;
+  const color = new THREE.Color(cell.colorHex || '#2ea043');
+  const emissive = color.clone().multiplyScalar(0.25 + cell.intensity * 0.15);
+  const posX = cell.col * 0.9;
+  const posZ = cell.row * 0.9;
+
+  const valid = cell.count > 0;
+
+  const handlePointerOver = (e: ThreeEvent<PointerEvent>) => {
+    e.stopPropagation();
+    if (valid) setHovered(cell);
+    onHoverNote?.(cell);
+  };
+
+  const handlePointerOut = () => setHovered(null);
+
+  const handleFocus = () => {
+    if (!valid) return;
+    setHovered(cell);
+    const v = new Vector3();
+    ref.current.getWorldPosition(v);
+    v.project(camera);
+    const x = (v.x * 0.5 + 0.5) * size.width;
+    const y = (-v.y * 0.5 + 0.5) * size.height;
+    setCursor({ x, y });
+  };
+
+  const handleBlur = () => setHovered(null);
+
+  return (
+    <mesh
+      ref={ref}
+      position={[posX, height / 2, posZ]}
+      onPointerOver={handlePointerOver}
+      onPointerOut={handlePointerOut}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      tabIndex={0}
+      userData={{ cell }}
+      castShadow
+      receiveShadow
+    >
+      <boxGeometry args={[0.8, height, 0.8]} />
+      <meshStandardMaterial color={color} emissive={emissive} />
+    </mesh>
+  );
+}

--- a/components/HeatmapTooltip.tsx
+++ b/components/HeatmapTooltip.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useHoverStore } from '@/lib/hoverStore';
+import { formatContribution, formatDateLong } from '@/lib/format';
+
+export function HeatmapTooltip() {
+  const hovered = useHoverStore((s) => s.hovered);
+  const cursor = useHoverStore((s) => s.cursor);
+  const [pos, setPos] = useState<{ left: number; top: number }>({ left: -9999, top: -9999 });
+
+  useEffect(() => {
+    if (!hovered || !cursor) return;
+    const PADDING = 12;
+    const OFFSET = 16;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    let left = cursor.x + OFFSET;
+    let top = cursor.y + OFFSET;
+    const boxW = 260;
+    const boxH = 56;
+    if (left + boxW + PADDING > vw) left = cursor.x - boxW - OFFSET;
+    if (top + boxH + PADDING > vh) top = cursor.y - boxH - OFFSET;
+    left = Math.max(PADDING, Math.min(vw - boxW - PADDING, left));
+    top = Math.max(PADDING, Math.min(vh - boxH - PADDING, top));
+    setPos({ left, top });
+  }, [hovered, cursor]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        useHoverStore.getState().setHovered(null);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  if (!hovered || !cursor) return null;
+
+  const text = `${formatContribution(hovered.count)} on ${formatDateLong(hovered.date)}`;
+
+  return createPortal(
+    <div
+      role="tooltip"
+      aria-hidden={false}
+      style={{ position: 'fixed', left: pos.left, top: pos.top, pointerEvents: 'none', zIndex: 50 }}
+      className="rounded-md border border-neutral-700 bg-neutral-900/95 px-3 py-2 text-sm text-neutral-100 shadow-xl backdrop-blur"
+    >
+      {text}
+    </div>,
+    document.body
+  );
+}

--- a/components/Uploader.tsx
+++ b/components/Uploader.tsx
@@ -48,6 +48,8 @@ function parseImage(img: HTMLImageElement): Grid {
   const cellW = img.width / cols;
   const cellH = img.height / rows;
 
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
   const cells: GridCell[] = [];
   for (let row = 0; row < rows; row++) {
     for (let col = 0; col < cols; col++) {
@@ -55,11 +57,15 @@ function parseImage(img: HTMLImageElement): Grid {
       const y = Math.floor(row * cellH + cellH / 2);
       const data = ctx.getImageData(x, y, 1, 1).data;
       const bucket = nearestBucket(data[0], data[1], data[2]);
+      const daysAgo = (cols - 1 - col) * 7 + row;
+      const d = new Date(today);
+      d.setDate(d.getDate() - daysAgo);
+      const iso = d.toISOString().slice(0, 10);
       cells.push({
-        date: '',
-        count: 0,
-        color: GH_COLORS[bucket],
-        intensity: bucket,
+        date: iso,
+        count: bucket,
+        colorHex: GH_COLORS[bucket],
+        intensity: bucket as 0 | 1 | 2 | 3 | 4,
         row,
         col,
         noteIndex: 0,

--- a/lib/contrib.ts
+++ b/lib/contrib.ts
@@ -44,7 +44,7 @@ export async function fetchContributionGrid(
       cells.push({
         date: d.date,
         count: d.count,
-        color: d.color,
+        colorHex: d.color,
         intensity: 0,
         row,
         col,

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,0 +1,9 @@
+export function formatContribution(count: number) {
+  return `${count} ${count === 1 ? 'contribution' : 'contributions'}`;
+}
+
+export function formatDateLong(iso: string) {
+  const d = new Date(iso);
+  const opts: Intl.DateTimeFormatOptions = { month: 'long', day: 'numeric', year: 'numeric' };
+  return new Intl.DateTimeFormat(undefined, opts).format(d);
+}

--- a/lib/hoverStore.ts
+++ b/lib/hoverStore.ts
@@ -1,0 +1,16 @@
+import { create } from 'zustand';
+import type { GridCell } from './types';
+
+type HoverState = {
+  hovered: GridCell | null;
+  cursor: { x: number; y: number } | null;
+  setHovered: (c: GridCell | null) => void;
+  setCursor: (p: { x: number; y: number }) => void;
+};
+
+export const useHoverStore = create<HoverState>((set) => ({
+  hovered: null,
+  cursor: null,
+  setHovered: (hovered) => set({ hovered }),
+  setCursor: (cursor) => set({ cursor }),
+}));

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,8 +1,8 @@
 export type GridCell = {
   date: string; // ISO date
   count: number; // contributionCount
-  color: string; // hex
-  intensity: number; // 0..4
+  colorHex: string; // hex color
+  intensity: 0 | 1 | 2 | 3 | 4; // bucket
   row: number; // 0..6 (Sun..Sat)
   col: number; // 0..N-1 (earliest..latest)
   noteIndex: number; // computed

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "react-dom": "18.3.1",
     "tailwindcss": "^3.4.4",
     "three": "^0.160.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "zustand": "^4.5.1"
   },
   "devDependencies": {
     "@types/node": "^20.12.12",


### PR DESCRIPTION
## Summary
- show tooltip with formatted contribution count and date
- track cursor globally with Zustand store
- render accessible tooltip overlay for hovered or focused grid cells

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: interactive ESLint config prompt)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6f1040b48322962e6c047add38d5