### PR TITLE
Add dedicated 2D heatmap page with navigation link

### DIFF
--- a/app/heatmap/page.tsx
+++ b/app/heatmap/page.tsx
@@ -1,0 +1,94 @@
+import Link from "next/link";
+
+const heatmapPalette = [
+  "#161b22",
+  "#0e4429",
+  "#006d32",
+  "#26a641",
+  "#39d353",
+];
+
+const ROWS = 7;
+const COLUMNS = 20;
+const highlightCells = [
+  { row: 5, column: 4 },
+  { row: 4, column: 8 },
+  { row: 3, column: 12 },
+  { row: 1, column: 16 },
+];
+
+const heatmapData: number[][] = Array.from({ length: ROWS }, (_, row) =>
+  Array.from({ length: COLUMNS }, (_, column) => {
+    const isHighlight = highlightCells.some(
+      (cell) => cell.row === row && cell.column === column
+    );
+    if (isHighlight) return 4;
+
+    const isNearHighlight = highlightCells.some(
+      (cell) =>
+        Math.abs(cell.row - row) + Math.abs(cell.column - column) === 1
+    );
+    if (isNearHighlight) return 2;
+
+    return 0;
+  })
+);
+
+export default function HeatmapPage() {
+  return (
+    <main className="min-h-screen bg-neutral-950 text-white">
+      <div className="max-w-5xl mx-auto p-6 flex flex-col gap-8">
+        <header className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <div>
+            <h1 className="text-2xl font-semibold">GitHub 2D Heatmap</h1>
+            <p className="opacity-70 text-sm">
+              A flat view inspired by GitHub&apos;s contribution calendar with familiar
+              green intensity levels.
+            </p>
+          </div>
+          <Link
+            href="/"
+            className="px-3 py-1 rounded bg-neutral-800 hover:bg-neutral-700"
+          >
+            ← Back to main experience
+          </Link>
+        </header>
+
+        <section className="rounded-lg border border-neutral-800 bg-neutral-900/40 p-6">
+          <div className="flex flex-col gap-4">
+            <div
+              className="grid gap-2"
+              style={{
+                gridTemplateColumns: `repeat(${heatmapData[0].length}, minmax(0, 1fr))`,
+              }}
+            >
+              {heatmapData.flatMap((row, rowIndex) =>
+                row.map((value, columnIndex) => (
+                  <div
+                    key={`${rowIndex}-${columnIndex}`}
+                    className="aspect-square rounded-sm border border-neutral-800"
+                    style={{ backgroundColor: heatmapPalette[value] }}
+                    aria-label={`Day ${columnIndex + 1}, intensity level ${value}`}
+                    title={`Day ${columnIndex + 1}: level ${value}`}
+                  />
+                ))
+              )}
+            </div>
+            <div className="flex items-center gap-2 text-xs text-neutral-400">
+              <span>Less</span>
+              {heatmapPalette.map((color, index) => (
+                <div
+                  key={color}
+                  className="h-3 w-3 rounded-sm border border-neutral-800"
+                  style={{ backgroundColor: color }}
+                  aria-label={`Legend intensity ${index}`}
+                />
+              ))}
+              <span>More</span>
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/app/heatmap/page.tsx
+++ b/app/heatmap/page.tsx
@@ -1,6 +1,15 @@
-import Link from "next/link";
+"use client";
 
-const heatmapPalette = [
+import Link from "next/link";
+import { HeatmapTooltip } from "@/components/HeatmapTooltip";
+import { PointerTracker } from "../PointerTracker";
+import { InstrumentSelect } from "@/components/InstrumentSelect";
+import { ContributionControls } from "@/components/experience/ContributionControls";
+import Transport from "@/components/Transport";
+import { Grid2D } from "@/components/Grid2D";
+import { useContributionExperience } from "@/components/experience/useContributionExperience";
+
+const GITHUB_PALETTE = [
   "#161b22",
   "#0e4429",
   "#006d32",
@@ -8,87 +17,106 @@ const heatmapPalette = [
   "#39d353",
 ];
 
-const ROWS = 7;
-const COLUMNS = 20;
-const highlightCells = [
-  { row: 5, column: 4 },
-  { row: 4, column: 8 },
-  { row: 3, column: 12 },
-  { row: 1, column: 16 },
-];
-
-const heatmapData: number[][] = Array.from({ length: ROWS }, (_, row) =>
-  Array.from({ length: COLUMNS }, (_, column) => {
-    const isHighlight = highlightCells.some(
-      (cell) => cell.row === row && cell.column === column
-    );
-    if (isHighlight) return 4;
-
-    const isNearHighlight = highlightCells.some(
-      (cell) =>
-        Math.abs(cell.row - row) + Math.abs(cell.column - column) === 1
-    );
-    if (isNearHighlight) return 2;
-
-    return 0;
-  })
-);
-
 export default function HeatmapPage() {
-  return (
-    <main className="min-h-screen bg-neutral-950 text-white">
-      <div className="max-w-5xl mx-auto p-6 flex flex-col gap-8">
-        <header className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-          <div>
-            <h1 className="text-2xl font-semibold">GitHub 2D Heatmap</h1>
-            <p className="opacity-70 text-sm">
-              A flat view inspired by GitHub&apos;s contribution calendar with familiar
-              green intensity levels.
-            </p>
-          </div>
-          <Link
-            href="/"
-            className="px-3 py-1 rounded bg-neutral-800 hover:bg-neutral-700"
-          >
-            ← Back to main experience
-          </Link>
-        </header>
+  const {
+    tab,
+    setTab,
+    username,
+    setUsername,
+    from,
+    setFrom,
+    to,
+    setTo,
+    grid,
+    loading,
+    error,
+    loadFromGithub,
+    handleUploadGrid,
+    playing,
+    togglePlay,
+    position,
+    duration,
+    bpm,
+    setBpm,
+    seekTo,
+    skipBy,
+    instrument,
+    changeInstrument,
+    previewCell,
+  } = useContributionExperience();
 
-        <section className="rounded-lg border border-neutral-800 bg-neutral-900/40 p-6">
-          <div className="flex flex-col gap-4">
-            <div
-              className="grid gap-2"
-              style={{
-                gridTemplateColumns: `repeat(${heatmapData[0].length}, minmax(0, 1fr))`,
-              }}
-            >
-              {heatmapData.flatMap((row, rowIndex) =>
-                row.map((value, columnIndex) => (
-                  <div
-                    key={`${rowIndex}-${columnIndex}`}
-                    className="aspect-square rounded-sm border border-neutral-800"
-                    style={{ backgroundColor: heatmapPalette[value] }}
-                    aria-label={`Day ${columnIndex + 1}, intensity level ${value}`}
-                    title={`Day ${columnIndex + 1}: level ${value}`}
-                  />
-                ))
-              )}
+  return (
+    <>
+      <PointerTracker />
+      <HeatmapTooltip />
+      <main className="min-h-screen bg-neutral-950 text-white">
+        <div className="max-w-6xl mx-auto p-4 flex flex-col gap-6">
+          <header className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3">
+            <div className="space-y-1">
+              <h1 className="text-2xl font-semibold">GitHub 2D Heatmap</h1>
+              <p className="opacity-70 text-sm">
+                Explore a flat contribution grid with the same musical controls and data sources as the 3D view.
+              </p>
             </div>
-            <div className="flex items-center gap-2 text-xs text-neutral-400">
+            <div className="flex items-center gap-2 flex-wrap">
+              <InstrumentSelect value={instrument} onChange={changeInstrument} />
+              <Link
+                href="/"
+                className="px-3 py-1 rounded bg-neutral-800 hover:bg-neutral-700"
+              >
+                ← Back to 3D experience
+              </Link>
+            </div>
+          </header>
+
+          <ContributionControls
+            tab={tab}
+            onTabChange={setTab}
+            username={username}
+            onUsernameChange={setUsername}
+            from={from}
+            to={to}
+            onFromChange={setFrom}
+            onToChange={setTo}
+            onLoadGithub={loadFromGithub}
+            loading={loading}
+            error={error}
+            onUpload={handleUploadGrid}
+          />
+
+          <section className="rounded-md border border-neutral-800 bg-neutral-900/40">
+            <Grid2D grid={grid} onHoverNote={previewCell} />
+            <div className="flex items-center gap-2 px-4 pb-4 text-xs text-neutral-400">
               <span>Less</span>
-              {heatmapPalette.map((color, index) => (
-                <div
+              {GITHUB_PALETTE.map((color) => (
+                <span
                   key={color}
                   className="h-3 w-3 rounded-sm border border-neutral-800"
                   style={{ backgroundColor: color }}
-                  aria-label={`Legend intensity ${index}`}
+                  aria-hidden
                 />
               ))}
               <span>More</span>
             </div>
-          </div>
-        </section>
-      </div>
-    </main>
+          </section>
+
+          <Transport
+            playing={playing}
+            onPlayPause={togglePlay}
+            onBack={() => skipBy(-15)}
+            onForward={() => skipBy(15)}
+            position={Math.min(position, duration)}
+            duration={duration}
+            onSeek={seekTo}
+            bpm={bpm}
+            onBpmChange={setBpm}
+          />
+
+          <footer className="opacity-60 text-xs">
+            Built with Next.js, Tailwind CSS, and the Web Audio API. © Natsuki.
+          </footer>
+        </div>
+      </main>
+    </>
   );
 }

--- a/app/heatmap/page.tsx
+++ b/app/heatmap/page.tsx
@@ -43,6 +43,7 @@ export default function HeatmapPage() {
     instrument,
     changeInstrument,
     previewCell,
+    activeCell,
   } = useContributionExperience();
 
   return (
@@ -85,7 +86,7 @@ export default function HeatmapPage() {
           />
 
           <section className="rounded-md border border-neutral-800 bg-neutral-900/40">
-            <Grid2D grid={grid} onHoverNote={previewCell} />
+            <Grid2D grid={grid} onHoverNote={previewCell} activeCell={activeCell} />
             <div className="flex items-center gap-2 px-4 pb-4 text-xs text-neutral-400">
               <span>Less</span>
               {GITHUB_PALETTE.map((color) => (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
 import { GridScene } from "@/components/Grid3D";
 import Transport from "@/components/Transport";
 import Uploader from "@/components/Uploader";
@@ -163,6 +164,12 @@ export default function Page() {
           >
             Upload
           </button>
+          <Link
+            href="/heatmap"
+            className="px-3 py-1 rounded bg-neutral-800 hover:bg-neutral-700"
+          >
+            2D Heatmap
+          </Link>
         </div>
       </header>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,262 +1,101 @@
 "use client";
 
-import React, { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { GridScene } from "@/components/Grid3D";
 import Transport from "@/components/Transport";
-import Uploader from "@/components/Uploader";
 import { InstrumentSelect } from "@/components/InstrumentSelect";
 import { HeatmapTooltip } from "@/components/HeatmapTooltip";
 import { PointerTracker } from "./PointerTracker";
-import { fetchContributionGrid } from "@/lib/contrib";
-import { mapGridToMusic } from "@/lib/mapping";
-import type { Grid, GridCell } from "@/lib/types";
-import { AudioEngine } from "@/lib/audio";
-import { getInstrumentFromUrl, setInstrumentInUrl } from "@/lib/state/urlParams";
-import type { InstrumentId } from "@/lib/instruments";
-import { format, subDays } from "date-fns";
-
-type Tab = "github" | "upload";
+import { useContributionExperience } from "@/components/experience/useContributionExperience";
+import { ContributionControls } from "@/components/experience/ContributionControls";
 
 export default function Page() {
-  const [tab, setTab] = useState<Tab>("github");
-  const [username, setUsername] = useState<string>("octocat");
-  const [from, setFrom] = useState<string>(
-    format(subDays(new Date(), 365), "yyyy-MM-dd")
-  );
-  const [to, setTo] = useState<string>(format(new Date(), "yyyy-MM-dd"));
-  const [grid, setGrid] = useState<Grid | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [err, setErr] = useState<string | null>(null);
-
-  const engineRef = useRef<AudioEngine | null>(null);
-  const [playing, setPlaying] = useState(false);
-  const [pos, setPos] = useState(0);
-  const [bpm, setBpm] = useState(90);
-  const [instrument, setInstrument] = useState<InstrumentId>("piano");
-
-  // init audio engine
-  useEffect(() => {
-    engineRef.current = new AudioEngine();
-    const e = engineRef.current;
-
-    const initial = (() => {
-      if (typeof window === "undefined") return "piano" as InstrumentId;
-      const urlInst = getInstrumentFromUrl();
-      const ls = localStorage.getItem("instrument") as InstrumentId | null;
-      return urlInst || ls || "piano";
-    })();
-    setInstrument(initial);
-    if (typeof window !== "undefined") {
-      setInstrumentInUrl(initial);
-    }
-    void e?.setInstrument(initial);
-
-    const id = setInterval(() => {
-      const eng = engineRef.current!;
-      setPos(eng.getPositionSec());
-    }, 100);
-    return () => clearInterval(id);
-  }, []);
-
-  // load data
-  const load = async () => {
-    try {
-      setLoading(true);
-      setErr(null);
-      const g = await fetchContributionGrid({
-        username,
-        from: new Date(from).toISOString(),
-        to: new Date(to).toISOString(),
-      });
-      const mapped = mapGridToMusic(g, { bpm });
-      setGrid(mapped);
-      const e = engineRef.current!;
-      e.setBpm(bpm);
-      e.attachGrid(mapped);
-      e.prepareScheduleFromGrid();
-      setPos(0);
-      setPlaying(false);
-    } catch (e: any) {
-      setErr(String(e));
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    load(); /* initial */
-  }, []);
-
-  // keep BPM in engine
-  useEffect(() => {
-    if (engineRef.current) {
-      engineRef.current.setBpm(bpm);
-      if (grid) {
-        engineRef.current.attachGrid(grid);
-        engineRef.current.prepareScheduleFromGrid();
-      }
-    }
-  }, [bpm]);
-
-  const duration = useMemo(
-    () => engineRef.current?.getTotalDurationSec() ?? 0,
-    [grid, bpm]
-  );
-
-  const togglePlay = () => {
-    const e = engineRef.current!;
-    if (!playing) {
-      e.play();
-      setPlaying(true);
-    } else {
-      e.pause();
-      setPlaying(false);
-    }
-  };
-
-  const onHoverNote = (cell: GridCell) => {
-    const e = engineRef.current!;
-    // map semitone to freq (baseHz is in engine)
-    const base = e.baseHz;
-    const freq = base * Math.pow(2, cell.noteIndex / 12);
-    e.preview(freq, cell.velocity, Math.max(0.12, cell.duration));
-  };
-
-  const changeInstrument = async (id: InstrumentId) => {
-    setInstrument(id);
-    if (typeof window !== "undefined") {
-      localStorage.setItem("instrument", id);
-      setInstrumentInUrl(id);
-    }
-    await engineRef.current?.setInstrument(id);
-  };
+  const {
+    tab,
+    setTab,
+    username,
+    setUsername,
+    from,
+    setFrom,
+    to,
+    setTo,
+    grid,
+    loading,
+    error,
+    loadFromGithub,
+    handleUploadGrid,
+    playing,
+    togglePlay,
+    position,
+    duration,
+    bpm,
+    setBpm,
+    seekTo,
+    skipBy,
+    instrument,
+    changeInstrument,
+    previewCell,
+  } = useContributionExperience();
 
   return (
     <>
       <PointerTracker />
       <HeatmapTooltip />
       <main className="max-w-6xl mx-auto p-4 flex flex-col gap-4">
-      <header className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3">
-        <div>
-          <h1 className="text-2xl font-semibold">ContriSonics</h1>
-          <p className="opacity-70 text-sm">3D GitHub contributions → music.</p>
-        </div>
-        <div className="flex items-center gap-2 flex-wrap">
-          <InstrumentSelect value={instrument} onChange={changeInstrument} />
-          <button
-            className={`px-3 py-1 rounded ${
-              tab === "github"
-                ? "bg-blue-600"
-                : "bg-neutral-800 hover:bg-neutral-700"
-            }`}
-            onClick={() => setTab("github")}
-          >
-            GitHub
-          </button>
-          <button
-            className={`px-3 py-1 rounded ${
-              tab === "upload"
-                ? "bg-blue-600"
-                : "bg-neutral-800 hover:bg-neutral-700"
-            }`}
-            onClick={() => setTab("upload")}
-          >
-            Upload
-          </button>
-          <Link
-            href="/heatmap"
-            className="px-3 py-1 rounded bg-neutral-800 hover:bg-neutral-700"
-          >
-            2D Heatmap
-          </Link>
-        </div>
-      </header>
-
-      {tab === "github" && (
-        <section className="flex flex-col gap-3 p-3 border border-neutral-800 rounded-md">
-          <div className="grid grid-cols-1 sm:grid-cols-4 gap-3">
-            <div className="col-span-2">
-              <label className="text-xs opacity-70">GitHub username</label>
-              <input
-                className="w-full px-3 py-2 rounded bg-neutral-900 border border-neutral-800"
-                value={username}
-                onChange={(e) => setUsername(e.target.value)}
-                placeholder="octocat"
-              />
-            </div>
-            <div>
-              <label className="text-xs opacity-70">From</label>
-              <input
-                type="date"
-                className="w-full px-3 py-2 rounded bg-neutral-900 border border-neutral-800"
-                value={from}
-                onChange={(e) => setFrom(e.target.value)}
-              />
-            </div>
-            <div>
-              <label className="text-xs opacity-70">To</label>
-              <input
-                type="date"
-                className="w-full px-3 py-2 rounded bg-neutral-900 border border-neutral-800"
-                value={to}
-                onChange={(e) => setTo(e.target.value)}
-              />
-            </div>
+        <header className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3">
+          <div>
+            <h1 className="text-2xl font-semibold">ContriSonics</h1>
+            <p className="opacity-70 text-sm">3D GitHub contributions → music.</p>
           </div>
-          <div className="flex gap-2">
-            <button
-              className="px-3 py-2 rounded bg-blue-600 hover:bg-blue-500 disabled:opacity-60"
-              onClick={load}
-              disabled={loading}
+          <div className="flex items-center gap-2 flex-wrap">
+            <InstrumentSelect value={instrument} onChange={changeInstrument} />
+            <Link
+              href="/heatmap"
+              className="px-3 py-1 rounded bg-neutral-800 hover:bg-neutral-700"
             >
-              {loading ? "Loading…" : "Load contributions"}
-            </button>
-            {err && <span className="text-red-400 text-sm">{err}</span>}
+              2D Heatmap
+            </Link>
           </div>
+        </header>
+
+        <ContributionControls
+          tab={tab}
+          onTabChange={setTab}
+          username={username}
+          onUsernameChange={setUsername}
+          from={from}
+          to={to}
+          onFromChange={setFrom}
+          onToChange={setTo}
+          onLoadGithub={loadFromGithub}
+          loading={loading}
+          error={error}
+          onUpload={handleUploadGrid}
+        />
+
+        <section className="h-[520px] rounded-md overflow-hidden border border-neutral-800">
+          {grid ? (
+            <GridScene grid={grid} onHoverNote={previewCell} />
+          ) : (
+            <div className="p-6 opacity-70">No grid loaded yet.</div>
+          )}
         </section>
-      )}
 
-      {tab === "upload" && (
-        <section className="flex flex-col gap-3">
-          <Uploader
-            onGridLoaded={(g) => {
-              const mapped = mapGridToMusic(g, { bpm });
-              setGrid(mapped);
-              const e = engineRef.current!;
-              e.setBpm(bpm);
-              e.attachGrid(mapped);
-              e.prepareScheduleFromGrid();
-              setPos(0);
-              setPlaying(false);
-            }}
-          />
-        </section>
-      )}
+        <Transport
+          playing={playing}
+          onPlayPause={togglePlay}
+          onBack={() => skipBy(-15)}
+          onForward={() => skipBy(15)}
+          position={Math.min(position, duration)}
+          duration={duration}
+          onSeek={seekTo}
+          bpm={bpm}
+          onBpmChange={setBpm}
+        />
 
-      <section className="h-[520px] rounded-md overflow-hidden border border-neutral-800">
-        {grid ? (
-          <GridScene grid={grid} onHoverNote={onHoverNote} />
-        ) : (
-          <div className="p-6 opacity-70">No grid loaded yet.</div>
-        )}
-      </section>
-
-      <Transport
-        playing={playing}
-        onPlayPause={togglePlay}
-        onBack={() => engineRef.current?.skip(-15)}
-        onForward={() => engineRef.current?.skip(15)}
-        position={Math.min(pos, duration)}
-        duration={duration}
-        onSeek={(s) => engineRef.current?.seekTo(s)}
-        bpm={bpm}
-        onBpmChange={setBpm}
-      />
-
-      <footer className="opacity-60 text-xs">
-        Built with Next.js, react-three-fiber, and the Web Audio API. © Natsuki.
-      </footer>
+        <footer className="opacity-60 text-xs">
+          Built with Next.js, react-three-fiber, and the Web Audio API. © Natsuki.
+        </footer>
       </main>
     </>
   );

--- a/components/Grid2D.tsx
+++ b/components/Grid2D.tsx
@@ -7,9 +7,10 @@ import { useCallback } from "react";
 type Props = {
   grid: Grid | null;
   onHoverNote?: (cell: GridCell) => void;
+  activeCell?: GridCell | null;
 };
 
-export function Grid2D({ grid, onHoverNote }: Props) {
+export function Grid2D({ grid, onHoverNote, activeCell }: Props) {
   const setHovered = useHoverStore((s) => s.setHovered);
   const setCursor = useHoverStore((s) => s.setCursor);
 
@@ -38,15 +39,25 @@ export function Grid2D({ grid, onHoverNote }: Props) {
     >
       {grid.cells.map((cell) => {
         const isActive = cell.intensity > 0;
+        const isCurrent =
+          activeCell?.row === cell.row && activeCell?.col === cell.col;
+        const classes = [
+          "aspect-square rounded-sm border transition-transform focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
+          isActive ? "border-neutral-700" : "border-neutral-900",
+          isCurrent
+            ? "ring-2 ring-emerald-400 ring-offset-2 ring-offset-neutral-900 scale-110 shadow-[0_0_12px_rgba(52,211,153,0.55)]"
+            : null,
+        ]
+          .filter(Boolean)
+          .join(" ");
         return (
           <button
             key={`${cell.row}-${cell.col}`}
             type="button"
-            className={`aspect-square rounded-sm border ${
-              isActive ? "border-neutral-700" : "border-neutral-900"
-            } focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500`}
+            className={classes}
             style={{ backgroundColor: cell.colorHex || "#161b22" }}
             aria-label={`${cell.count} contributions on ${cell.date}`}
+            data-active={isCurrent ? "true" : undefined}
             onMouseEnter={() => {
               if (isActive) setHovered(cell);
               onHoverNote?.(cell);

--- a/components/Grid2D.tsx
+++ b/components/Grid2D.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import type { Grid, GridCell } from "@/lib/types";
+import { useHoverStore } from "@/lib/hoverStore";
+import { useCallback } from "react";
+
+type Props = {
+  grid: Grid | null;
+  onHoverNote?: (cell: GridCell) => void;
+};
+
+export function Grid2D({ grid, onHoverNote }: Props) {
+  const setHovered = useHoverStore((s) => s.setHovered);
+  const setCursor = useHoverStore((s) => s.setCursor);
+
+  const handleFocus = useCallback(
+    (cell: GridCell, element: HTMLButtonElement | null) => {
+      if (!element) return;
+      setHovered(cell);
+      const rect = element.getBoundingClientRect();
+      setCursor({ x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 });
+      onHoverNote?.(cell);
+    },
+    [onHoverNote, setCursor, setHovered]
+  );
+
+  if (!grid) {
+    return <div className="p-6 opacity-70">No grid loaded yet.</div>;
+  }
+
+  return (
+    <div
+      className="grid gap-1 p-3"
+      style={{
+        gridTemplateColumns: `repeat(${grid.cols}, minmax(0, 1fr))`,
+        gridTemplateRows: `repeat(${grid.rows}, minmax(0, 1fr))`,
+      }}
+    >
+      {grid.cells.map((cell) => {
+        const isActive = cell.intensity > 0;
+        return (
+          <button
+            key={`${cell.row}-${cell.col}`}
+            type="button"
+            className={`aspect-square rounded-sm border ${
+              isActive ? "border-neutral-700" : "border-neutral-900"
+            } focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500`}
+            style={{ backgroundColor: cell.colorHex || "#161b22" }}
+            aria-label={`${cell.count} contributions on ${cell.date}`}
+            onMouseEnter={() => {
+              if (isActive) setHovered(cell);
+              onHoverNote?.(cell);
+            }}
+            onMouseLeave={() => setHovered(null)}
+            onFocus={(e) => handleFocus(cell, e.currentTarget)}
+            onBlur={() => setHovered(null)}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/components/experience/ContributionControls.tsx
+++ b/components/experience/ContributionControls.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import Uploader from "@/components/Uploader";
+import type { Grid } from "@/lib/types";
+import type { ExperienceTab } from "./useContributionExperience";
+
+type Props = {
+  tab: ExperienceTab;
+  onTabChange: (tab: ExperienceTab) => void;
+  username: string;
+  onUsernameChange: (value: string) => void;
+  from: string;
+  to: string;
+  onFromChange: (value: string) => void;
+  onToChange: (value: string) => void;
+  onLoadGithub: () => void | Promise<void>;
+  loading: boolean;
+  error: string | null;
+  onUpload: (grid: Grid) => void;
+};
+
+export function ContributionControls({
+  tab,
+  onTabChange,
+  username,
+  onUsernameChange,
+  from,
+  to,
+  onFromChange,
+  onToChange,
+  onLoadGithub,
+  loading,
+  error,
+  onUpload,
+}: Props) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-2 flex-wrap">
+        <button
+          type="button"
+          className={`px-3 py-1 rounded ${
+            tab === "github"
+              ? "bg-blue-600"
+              : "bg-neutral-800 hover:bg-neutral-700"
+          }`}
+          onClick={() => onTabChange("github")}
+        >
+          GitHub
+        </button>
+        <button
+          type="button"
+          className={`px-3 py-1 rounded ${
+            tab === "upload"
+              ? "bg-blue-600"
+              : "bg-neutral-800 hover:bg-neutral-700"
+          }`}
+          onClick={() => onTabChange("upload")}
+        >
+          Upload
+        </button>
+      </div>
+
+      {tab === "github" && (
+        <section className="flex flex-col gap-3 p-3 border border-neutral-800 rounded-md">
+          <div className="grid grid-cols-1 sm:grid-cols-4 gap-3">
+            <div className="col-span-2">
+              <label className="text-xs opacity-70">GitHub username</label>
+              <input
+                className="w-full px-3 py-2 rounded bg-neutral-900 border border-neutral-800"
+                value={username}
+                onChange={(e) => onUsernameChange(e.target.value)}
+                placeholder="octocat"
+              />
+            </div>
+            <div>
+              <label className="text-xs opacity-70">From</label>
+              <input
+                type="date"
+                className="w-full px-3 py-2 rounded bg-neutral-900 border border-neutral-800"
+                value={from}
+                onChange={(e) => onFromChange(e.target.value)}
+              />
+            </div>
+            <div>
+              <label className="text-xs opacity-70">To</label>
+              <input
+                type="date"
+                className="w-full px-3 py-2 rounded bg-neutral-900 border border-neutral-800"
+                value={to}
+                onChange={(e) => onToChange(e.target.value)}
+              />
+            </div>
+          </div>
+          <div className="flex gap-2 items-center">
+            <button
+              type="button"
+              className="px-3 py-2 rounded bg-blue-600 hover:bg-blue-500 disabled:opacity-60"
+              onClick={onLoadGithub}
+              disabled={loading}
+            >
+              {loading ? "Loading…" : "Load contributions"}
+            </button>
+            {error && <span className="text-red-400 text-sm">{error}</span>}
+          </div>
+        </section>
+      )}
+
+      {tab === "upload" && (
+        <Uploader
+          onGridLoaded={(grid) => {
+            onUpload(grid);
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/components/experience/useContributionExperience.ts
+++ b/components/experience/useContributionExperience.ts
@@ -27,6 +27,7 @@ export function useContributionExperience() {
   const [position, setPosition] = useState(0);
   const [bpm, setBpm] = useState(90);
   const [instrument, setInstrument] = useState<InstrumentId>("piano");
+  const [activeCell, setActiveCell] = useState<GridCell | null>(null);
 
   useEffect(() => {
     engineRef.current = new AudioEngine();
@@ -44,6 +45,9 @@ export function useContributionExperience() {
       setInstrumentInUrl(initialInstrument);
     }
     void engine?.setInstrument(initialInstrument);
+    engine?.setActiveCellListener((cell) => {
+      setActiveCell(cell);
+    });
 
     const timer = window.setInterval(() => {
       const eng = engineRef.current;
@@ -54,7 +58,10 @@ export function useContributionExperience() {
 
     return () => {
       window.clearInterval(timer);
-      engineRef.current?.pause();
+      if (engineRef.current) {
+        engineRef.current.setActiveCellListener(null);
+        engineRef.current.pause();
+      }
     };
   }, []);
 
@@ -71,6 +78,7 @@ export function useContributionExperience() {
       }
       setPosition(0);
       setPlaying(false);
+      setActiveCell(null);
     },
     [bpm]
   );
@@ -188,5 +196,6 @@ export function useContributionExperience() {
     instrument,
     changeInstrument,
     previewCell,
+    activeCell,
   } as const;
 }

--- a/components/experience/useContributionExperience.ts
+++ b/components/experience/useContributionExperience.ts
@@ -1,0 +1,192 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { AudioEngine } from "@/lib/audio";
+import { fetchContributionGrid } from "@/lib/contrib";
+import { mapGridToMusic } from "@/lib/mapping";
+import type { Grid, GridCell } from "@/lib/types";
+import { format, subDays } from "date-fns";
+import type { InstrumentId } from "@/lib/instruments";
+import { getInstrumentFromUrl, setInstrumentInUrl } from "@/lib/state/urlParams";
+
+export type ExperienceTab = "github" | "upload";
+
+export function useContributionExperience() {
+  const [tab, setTab] = useState<ExperienceTab>("github");
+  const [username, setUsername] = useState<string>("octocat");
+  const [from, setFrom] = useState<string>(
+    format(subDays(new Date(), 365), "yyyy-MM-dd")
+  );
+  const [to, setTo] = useState<string>(format(new Date(), "yyyy-MM-dd"));
+  const [grid, setGrid] = useState<Grid | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const engineRef = useRef<AudioEngine | null>(null);
+  const [playing, setPlaying] = useState(false);
+  const [position, setPosition] = useState(0);
+  const [bpm, setBpm] = useState(90);
+  const [instrument, setInstrument] = useState<InstrumentId>("piano");
+
+  useEffect(() => {
+    engineRef.current = new AudioEngine();
+    const engine = engineRef.current;
+
+    const initialInstrument = (() => {
+      if (typeof window === "undefined") return "piano" as InstrumentId;
+      const urlInst = getInstrumentFromUrl();
+      const stored = localStorage.getItem("instrument") as InstrumentId | null;
+      return urlInst || stored || "piano";
+    })();
+
+    setInstrument(initialInstrument);
+    if (typeof window !== "undefined") {
+      setInstrumentInUrl(initialInstrument);
+    }
+    void engine?.setInstrument(initialInstrument);
+
+    const timer = window.setInterval(() => {
+      const eng = engineRef.current;
+      if (eng) {
+        setPosition(eng.getPositionSec());
+      }
+    }, 100);
+
+    return () => {
+      window.clearInterval(timer);
+      engineRef.current?.pause();
+    };
+  }, []);
+
+  const applyGrid = useCallback(
+    (source: Grid) => {
+      const mapped = mapGridToMusic(source, { bpm });
+      setGrid(mapped);
+      const engine = engineRef.current;
+      if (engine) {
+        engine.setBpm(bpm);
+        engine.attachGrid(mapped);
+        engine.prepareScheduleFromGrid();
+        engine.stop();
+      }
+      setPosition(0);
+      setPlaying(false);
+    },
+    [bpm]
+  );
+
+  const loadFromGithub = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await fetchContributionGrid({
+        username,
+        from: new Date(from).toISOString(),
+        to: new Date(to).toISOString(),
+      });
+      applyGrid(data);
+    } catch (e: any) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [username, from, to, applyGrid]);
+
+  const handleUploadGrid = useCallback(
+    (uploaded: Grid) => {
+      applyGrid(uploaded);
+    },
+    [applyGrid]
+  );
+
+  useEffect(() => {
+    void loadFromGithub();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const engine = engineRef.current;
+    if (engine) {
+      engine.setBpm(bpm);
+      if (grid) {
+        engine.attachGrid(grid);
+        engine.prepareScheduleFromGrid();
+      }
+    }
+  }, [bpm, grid]);
+
+  const duration = useMemo(
+    () => engineRef.current?.getTotalDurationSec() ?? 0,
+    [grid, bpm]
+  );
+
+  const togglePlay = useCallback(() => {
+    const engine = engineRef.current;
+    if (!engine) return;
+    if (!playing) {
+      engine.play();
+      setPlaying(true);
+    } else {
+      engine.pause();
+      setPlaying(false);
+    }
+  }, [playing]);
+
+  const previewCell = useCallback((cell: GridCell) => {
+    const engine = engineRef.current;
+    if (!engine) return;
+    const base = engine.baseHz;
+    const freq = base * Math.pow(2, cell.noteIndex / 12);
+    engine.preview(freq, cell.velocity, Math.max(0.12, cell.duration));
+  }, []);
+
+  const changeInstrument = useCallback(async (id: InstrumentId) => {
+    setInstrument(id);
+    if (typeof window !== "undefined") {
+      localStorage.setItem("instrument", id);
+      setInstrumentInUrl(id);
+    }
+    await engineRef.current?.setInstrument(id);
+  }, []);
+
+  const seekTo = useCallback((seconds: number) => {
+    const engine = engineRef.current;
+    if (!engine) return;
+    engine.seekTo(seconds);
+    setPosition(engine.getPositionSec());
+  }, []);
+
+  const skipBy = useCallback((seconds: number) => {
+    const engine = engineRef.current;
+    if (!engine) return;
+    engine.skip(seconds);
+    setPosition(engine.getPositionSec());
+  }, []);
+
+  return {
+    tab,
+    setTab,
+    username,
+    setUsername,
+    from,
+    setFrom,
+    to,
+    setTo,
+    grid,
+    loading,
+    error,
+    loadFromGithub,
+    handleUploadGrid,
+    playing,
+    togglePlay,
+    position,
+    duration,
+    bpm,
+    setBpm,
+    seekTo,
+    skipBy,
+    instrument,
+    changeInstrument,
+    previewCell,
+  } as const;
+}


### PR DESCRIPTION
## Summary
- add a navigation button on the main dashboard to reach the new 2D heatmap view
- create a dedicated page that renders a GitHub-style contribution grid with legend and link back home

## Testing
- npm run lint *(fails: unable to install project dependencies because required packages on the npm registry return 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d646c58f6c8322b602fe2236d0a8ee