### PR TITLE
fix: replace mobile preview png with svg

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+
 import { GridScene } from "@/components/Grid3D";
 import Transport from "@/components/Transport";
 import { InstrumentSelect } from "@/components/InstrumentSelect";
@@ -8,8 +9,11 @@ import { HeatmapTooltip } from "@/components/HeatmapTooltip";
 import { PointerTracker } from "./PointerTracker";
 import { useContributionExperience } from "@/components/experience/useContributionExperience";
 import { ContributionControls } from "@/components/experience/ContributionControls";
+import { LiteApp } from "@/components/LiteApp";
+import { MobileFallback } from "@/components/MobileFallback";
+import { useMedia } from "@/hooks/useMedia";
 
-export default function Page() {
+function DesktopApp() {
   const {
     tab,
     setTab,
@@ -41,17 +45,17 @@ export default function Page() {
     <>
       <PointerTracker />
       <HeatmapTooltip />
-      <main className="max-w-6xl mx-auto p-4 flex flex-col gap-4">
-        <header className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3">
+      <main className="mx-auto flex max-w-6xl flex-col gap-4 p-4">
+        <header className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <h1 className="text-2xl font-semibold">ContriSonics</h1>
-            <p className="opacity-70 text-sm">3D GitHub contributions → music.</p>
+            <p className="text-sm opacity-70">3D GitHub contributions → music.</p>
           </div>
-          <div className="flex items-center gap-2 flex-wrap">
+          <div className="flex flex-wrap items-center gap-2">
             <InstrumentSelect value={instrument} onChange={changeInstrument} />
             <Link
               href="/heatmap"
-              className="px-3 py-1 rounded bg-neutral-800 hover:bg-neutral-700"
+              className="rounded bg-neutral-800 px-3 py-1 hover:bg-neutral-700"
             >
               2D Heatmap
             </Link>
@@ -73,9 +77,11 @@ export default function Page() {
           onUpload={handleUploadGrid}
         />
 
-        <section className="h-[520px] rounded-md overflow-hidden border border-neutral-800">
+        <section className="overflow-hidden rounded-md border border-neutral-800">
           {grid ? (
-            <GridScene grid={grid} onHoverNote={previewCell} />
+            <div className="mx-auto w-[min(1200px,95vw)] aspect-[16/9]">
+              <GridScene grid={grid} onHoverNote={previewCell} />
+            </div>
           ) : (
             <div className="p-6 opacity-70">No grid loaded yet.</div>
           )}
@@ -93,10 +99,32 @@ export default function Page() {
           onBpmChange={setBpm}
         />
 
-        <footer className="opacity-60 text-xs">
+        <footer className="text-xs opacity-60">
           Built with Next.js, react-three-fiber, and the Web Audio API. © Natsuki.
         </footer>
       </main>
     </>
   );
+}
+
+export default function Page() {
+  const media = useMedia();
+
+  if (!media.ready) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-neutral-950 text-neutral-300">
+        Loading experience…
+      </main>
+    );
+  }
+
+  if (media.isMobile) {
+    return <MobileFallback />;
+  }
+
+  if (media.isTablet) {
+    return <LiteApp />;
+  }
+
+  return <DesktopApp />;
 }

--- a/components/Grid3D.tsx
+++ b/components/Grid3D.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import React, { useMemo } from 'react';
-import { Canvas } from '@react-three/fiber';
+import React, { useEffect, useMemo } from 'react';
+import { Canvas, useThree } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
 import type { Grid, GridCell } from '@/lib/types';
 import { GridCell3D } from './GridCell3D';
@@ -18,7 +18,17 @@ export function GridScene({ grid, onHoverNote }: Props) {
   }), [grid]);
 
   return (
-    <Canvas camera={{ position: [size.w * 0.6, 12, size.h * 1.1], fov: 50 }} shadows>
+    <Canvas
+      className="h-full w-full"
+      camera={{ position: [size.w * 0.6, 12, size.h * 1.1], fov: 50 }}
+      shadows
+      onCreated={({ gl }) => {
+        if (typeof window !== 'undefined') {
+          gl.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+        }
+      }}
+    >
+      <VisibilityController />
       <ambientLight intensity={0.6} />
       <directionalLight position={[5, 10, 5]} intensity={1.0} castShadow />
       <group position={[-size.w/2, 0, -size.h/2]}>
@@ -33,4 +43,19 @@ export function GridScene({ grid, onHoverNote }: Props) {
       <OrbitControls enablePan={false} minPolarAngle={Math.PI/4} maxPolarAngle={Math.PI/3} />
     </Canvas>
   );
+}
+
+function VisibilityController() {
+  const setFrameloop = useThree((state) => state.setFrameloop);
+
+  useEffect(() => {
+    const handle = () => {
+      setFrameloop(document.hidden ? 'never' : 'always');
+    };
+    handle();
+    document.addEventListener('visibilitychange', handle);
+    return () => document.removeEventListener('visibilitychange', handle);
+  }, [setFrameloop]);
+
+  return null;
 }

--- a/components/GridCell3D.tsx
+++ b/components/GridCell3D.tsx
@@ -52,6 +52,7 @@ export function GridCell3D({ cell, onHoverNote }: Props) {
       ref={ref}
       position={[posX, height / 2, posZ]}
       onPointerOver={handlePointerOver}
+      onPointerDown={handlePointerOver}
       onPointerOut={handlePointerOut}
       onFocus={handleFocus}
       onBlur={handleBlur}

--- a/components/InstrumentSelect.tsx
+++ b/components/InstrumentSelect.tsx
@@ -2,18 +2,32 @@
 
 import type { InstrumentId } from "@/lib/instruments";
 
-export function InstrumentSelect({ value, onChange }: { value: InstrumentId; onChange: (v: InstrumentId)=>void }) {
+type Props = {
+  value: InstrumentId;
+  onChange: (v: InstrumentId) => void;
+  size?: "md" | "lg";
+};
+
+export function InstrumentSelect({ value, onChange, size = "md" }: Props) {
   const opts: {id: InstrumentId; label: string}[] = [
     {id:"metal",label:"Metal"},
     {id:"piano",label:"Piano"},
     {id:"organ",label:"Organ"},
     {id:"synth",label:"Synth"},
   ];
+
+  const labelClass =
+    size === "lg" ? "text-base font-medium" : "text-sm opacity-80";
+  const selectClass =
+    size === "lg"
+      ? "border rounded px-3 py-2 text-base bg-neutral-900"
+      : "border rounded px-2 py-1 bg-neutral-900";
+
   return (
     <label className="flex items-center gap-2">
-      <span className="text-sm opacity-80">Instrument</span>
+      <span className={labelClass}>Instrument</span>
       <select
-        className="border rounded px-2 py-1 bg-neutral-900"
+        className={selectClass}
         value={value}
         onChange={e=>onChange(e.target.value as InstrumentId)}
         aria-label="Instrument"

--- a/components/LiteApp.tsx
+++ b/components/LiteApp.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import { Canvas, ThreeEvent, useThree } from "@react-three/fiber";
+import {
+  AdaptiveDpr,
+  OrbitControls,
+  PerformanceMonitor,
+} from "@react-three/drei";
+import type { OrbitControls as OrbitControlsImpl } from "three/examples/jsm/controls/OrbitControls";
+import { Color } from "three";
+
+import { ContributionControls } from "@/components/experience/ContributionControls";
+import { useContributionExperience } from "@/components/experience/useContributionExperience";
+import Transport from "@/components/Transport";
+import { InstrumentSelect } from "@/components/InstrumentSelect";
+import type { Grid, GridCell } from "@/lib/types";
+import { formatContribution, formatDateLong } from "@/lib/format";
+
+export function LiteApp() {
+  const {
+    tab,
+    setTab,
+    username,
+    setUsername,
+    from,
+    setFrom,
+    to,
+    setTo,
+    grid,
+    loading,
+    error,
+    loadFromGithub,
+    handleUploadGrid,
+    playing,
+    togglePlay,
+    position,
+    duration,
+    bpm,
+    setBpm,
+    seekTo,
+    skipBy,
+    instrument,
+    changeInstrument,
+    previewCell,
+    activeCell,
+  } = useContributionExperience();
+
+  const [quality, setQuality] = useState<"high" | "low">("high");
+  const [previewedCell, setPreviewedCell] = useState<GridCell | null>(null);
+  const controlsRef = useRef<OrbitControlsImpl | null>(null);
+
+  useEffect(() => {
+    setPreviewedCell(null);
+  }, [grid]);
+
+  const cameraPosition = useMemo(() => {
+    const cols = grid?.cols ?? 28;
+    const rows = grid?.rows ?? 7;
+    const span = Math.max(cols, rows) * 0.6;
+    return [span + 8, Math.max(10, span + 4), span * 1.2 + 6] as [number, number, number];
+  }, [grid]);
+
+  const currentCell = previewedCell ?? activeCell;
+
+  const activeSummary = currentCell
+    ? `${formatContribution(currentCell.count)} on ${formatDateLong(currentCell.date)}`
+    : "Tap a column to preview its sound.";
+
+  const handleSelectCell = (cell: GridCell) => {
+    if (cell.count <= 0) return;
+    setPreviewedCell(cell);
+    previewCell(cell);
+  };
+
+  const handleResetView = () => {
+    controlsRef.current?.reset();
+    controlsRef.current?.update();
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col gap-6 bg-neutral-950 px-5 py-6 text-neutral-100">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold">ContriSonics Lite</h1>
+        <p className="text-base text-neutral-400">
+          Streamlined tablet mode with adaptive quality controls.
+        </p>
+      </header>
+
+      <div className="flex flex-col gap-5">
+        <div className="flex flex-wrap items-center justify-between gap-4 rounded-lg border border-neutral-800 bg-neutral-900/40 p-4">
+          <InstrumentSelect value={instrument} onChange={changeInstrument} size="lg" />
+          <Link
+            href="/heatmap"
+            className="rounded-full bg-blue-600 px-5 py-3 text-base font-semibold text-white hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-300"
+          >
+            Open 2D Heatmap
+          </Link>
+        </div>
+
+        <ContributionControls
+          tab={tab}
+          onTabChange={setTab}
+          username={username}
+          onUsernameChange={setUsername}
+          from={from}
+          to={to}
+          onFromChange={setFrom}
+          onToChange={setTo}
+          onLoadGithub={loadFromGithub}
+          loading={loading}
+          error={error}
+          onUpload={handleUploadGrid}
+          variant="touch"
+        />
+
+        <div className="space-y-3">
+          <div className="mx-auto w-[min(1200px,95vw)] aspect-[16/9] overflow-hidden rounded-xl border border-neutral-800 bg-neutral-950/80">
+            {grid ? (
+              <Canvas
+                camera={{ position: cameraPosition, fov: 55 }}
+                dpr={[1, 2]}
+                onCreated={({ gl }) => {
+                  if (typeof window !== "undefined") {
+                    gl.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+                  }
+                }}
+              >
+                <VisibilityController />
+                <AdaptiveDpr pixelated />
+                <PerformanceMonitor
+                  onDecline={() => setQuality("low")}
+                  onIncline={() => setQuality("high")}
+                />
+                <LiteScene
+                  grid={grid}
+                  onSelectCell={handleSelectCell}
+                  quality={quality}
+                  controlsRef={controlsRef}
+                />
+              </Canvas>
+            ) : (
+              <div className="flex h-full items-center justify-center px-6 text-center text-neutral-500">
+                Load a contribution grid to explore it in 3D.
+              </div>
+            )}
+          </div>
+
+          <div className="text-center text-sm text-neutral-300">{activeSummary}</div>
+
+          <div className="flex justify-center">
+            <button
+              type="button"
+              onClick={handleResetView}
+              className="rounded-full bg-neutral-200 px-6 py-3 text-base font-medium text-neutral-900 shadow focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+            >
+              Reset View
+            </button>
+          </div>
+        </div>
+
+        <Transport
+          playing={playing}
+          onPlayPause={togglePlay}
+          onBack={() => skipBy(-15)}
+          onForward={() => skipBy(15)}
+          position={Math.min(position, duration)}
+          duration={duration}
+          onSeek={seekTo}
+          bpm={bpm}
+          onBpmChange={setBpm}
+          size="lg"
+        />
+      </div>
+
+      <footer className="pt-6 text-sm text-neutral-500">
+        Optimized for tablets. Switch to desktop for shadows and the full 3D treatment.
+      </footer>
+    </div>
+  );
+}
+
+function LiteScene({
+  grid,
+  onSelectCell,
+  quality,
+  controlsRef,
+}: {
+  grid: Grid;
+  onSelectCell: (cell: GridCell) => void;
+  quality: "high" | "low";
+  controlsRef: React.RefObject<OrbitControlsImpl>;
+}) {
+  const spacing = quality === "high" ? 0.82 : 0.95;
+  const heightScale = quality === "high" ? 0.32 : 0.24;
+  const { cols, rows } = grid;
+  const offset = useMemo(
+    () => ({
+      x: -(cols * spacing) / 2,
+      z: -(rows * spacing) / 2,
+    }),
+    [cols, rows, spacing]
+  );
+
+  return (
+    <group>
+      <color attach="background" args={["#050506"]} />
+      <hemisphereLight args={["#f8fafc", "#0f172a", 0.85]} />
+      <directionalLight position={[10, 12, 6]} intensity={0.65} />
+      <group position={[offset.x, 0, offset.z]}>
+        <mesh rotation-x={-Math.PI / 2}>
+          <planeGeometry args={[Math.max(12, cols * spacing + 4), Math.max(12, rows * spacing + 4)]} />
+          <meshStandardMaterial color="#111217" />
+        </mesh>
+        {grid.cells.map((cell) => (
+          <LiteColumn
+            key={`${cell.row}-${cell.col}`}
+            cell={cell}
+            spacing={spacing}
+            heightScale={heightScale}
+            onSelect={onSelectCell}
+          />
+        ))}
+      </group>
+      <OrbitControls
+        ref={controlsRef}
+        enablePan={false}
+        enableDamping
+        dampingFactor={0.08}
+        minPolarAngle={Math.PI / 4}
+        maxPolarAngle={Math.PI / 2.3}
+      />
+    </group>
+  );
+}
+
+function LiteColumn({
+  cell,
+  spacing,
+  heightScale,
+  onSelect,
+}: {
+  cell: GridCell;
+  spacing: number;
+  heightScale: number;
+  onSelect: (cell: GridCell) => void;
+}) {
+  const height = 0.18 + cell.intensity * heightScale;
+  const color = new Color(cell.colorHex ?? "#2ea043");
+  const emissive = color.clone().multiplyScalar(0.18 + cell.intensity * 0.12);
+
+  const handleInteract = (event: ThreeEvent<PointerEvent>) => {
+    event.stopPropagation();
+    if (cell.count <= 0) return;
+    onSelect(cell);
+  };
+
+  return (
+    <mesh
+      position={[cell.col * spacing, height / 2, cell.row * spacing]}
+      onPointerDown={handleInteract}
+      onPointerEnter={handleInteract}
+      onFocus={(event) => {
+        if (cell.count <= 0) return;
+        event.stopPropagation();
+        onSelect(cell);
+      }}
+      tabIndex={cell.count > 0 ? 0 : -1}
+    >
+      <boxGeometry args={[spacing * 0.7, height, spacing * 0.7]} />
+      <meshStandardMaterial color={color} emissive={emissive} flatShading />
+    </mesh>
+  );
+}
+
+function VisibilityController() {
+  const setFrameloop = useThree((state) => state.setFrameloop);
+
+  useEffect(() => {
+    const handleVisibility = () => {
+      setFrameloop(document.hidden ? "never" : "always");
+    };
+    handleVisibility();
+    document.addEventListener("visibilitychange", handleVisibility);
+    return () => document.removeEventListener("visibilitychange", handleVisibility);
+  }, [setFrameloop]);
+
+  return null;
+}

--- a/components/MobileFallback.tsx
+++ b/components/MobileFallback.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import Image from "next/image";
+
+export function MobileFallback() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-neutral-950 px-6 py-10 text-center text-neutral-100">
+      <div className="max-w-md space-y-4">
+        <h1 className="text-2xl font-semibold">ContriSonics</h1>
+        <p className="text-base leading-relaxed text-neutral-300">
+          This demo is optimized for larger screens. For the full 3D experience, please open on a desktop.
+        </p>
+      </div>
+      <div className="relative h-48 w-80 overflow-hidden rounded-xl border border-neutral-800 bg-neutral-900">
+        <Image
+          src="/preview-light.svg"
+          alt="Preview of the ContriSonics 3D scene"
+          fill
+          className="object-cover opacity-80"
+          sizes="320px"
+          priority
+        />
+      </div>
+      <p className="text-sm text-neutral-500">
+        Tip: rotate your device or visit again on a tablet/desktop for an interactive mode.
+      </p>
+    </main>
+  );
+}

--- a/components/Transport.tsx
+++ b/components/Transport.tsx
@@ -12,28 +12,63 @@ type Props = {
   onSeek: (sec: number) => void;
   bpm: number;
   onBpmChange: (bpm: number) => void;
+  size?: "md" | "lg";
+  className?: string;
 };
 
 export default function Transport({
-  playing, onPlayPause, onBack, onForward,
-  position, duration, onSeek,
-  bpm, onBpmChange
+  playing,
+  onPlayPause,
+  onBack,
+  onForward,
+  position,
+  duration,
+  onSeek,
+  bpm,
+  onBpmChange,
+  size = "md",
+  className,
 }: Props) {
-  const pct = duration > 0 ? (position / duration) * 100 : 0;
+  const isLarge = size === "lg";
+  const gapClass = isLarge ? "gap-3" : "gap-2";
+  const paddingClass = isLarge ? "p-3" : "p-2";
+  const containerClasses = `flex flex-col ${gapClass} ${paddingClass} bg-neutral-900/60 rounded-md ${
+    className ?? ""
+  }`;
+  const buttonBase = isLarge
+    ? "rounded bg-neutral-800 hover:bg-neutral-700 px-4 py-2 text-base"
+    : "rounded bg-neutral-800 hover:bg-neutral-700 px-3 py-1";
+  const primaryButton = isLarge
+    ? "rounded bg-blue-600 hover:bg-blue-500 px-5 py-2 text-base"
+    : "rounded bg-blue-600 hover:bg-blue-500 px-4 py-1";
+  const sliderClass = isLarge ? "h-2" : "";
+  const bpmLabel = isLarge ? "text-sm" : "text-sm opacity-80";
+  const bpmWrapper = isLarge ? "ml-0 sm:ml-4 gap-3" : "ml-4 gap-2";
 
   return (
-    <div className="flex flex-col gap-2 p-2 bg-neutral-900/60 rounded-md">
-      <div className="flex items-center gap-2">
-        <button className="px-3 py-1 rounded bg-neutral-800 hover:bg-neutral-700" onClick={onBack}>⏪ 15s</button>
-        <button className="px-4 py-1 rounded bg-blue-600 hover:bg-blue-500" onClick={onPlayPause}>
+    <div className={containerClasses.trim()}>
+      <div className="flex flex-wrap items-center gap-3">
+        <button className={buttonBase} onClick={onBack}>
+          ⏪ 15s
+        </button>
+        <button className={primaryButton} onClick={onPlayPause}>
           {playing ? '⏸ Pause' : '▶️ Play'}
         </button>
-        <button className="px-3 py-1 rounded bg-neutral-800 hover:bg-neutral-700" onClick={onForward}>15s ⏩</button>
+        <button className={buttonBase} onClick={onForward}>
+          15s ⏩
+        </button>
 
-        <div className="ml-4 flex items-center gap-2">
-          <label className="text-sm opacity-80">BPM</label>
-          <input type="range" min={60} max={140} value={bpm} onChange={e => onBpmChange(parseInt(e.target.value))} />
-          <span className="w-10 text-right">{bpm}</span>
+        <div className={`flex items-center ${bpmWrapper}`}>
+          <label className={bpmLabel}>BPM</label>
+          <input
+            type="range"
+            min={60}
+            max={140}
+            value={bpm}
+            onChange={e => onBpmChange(parseInt(e.target.value))}
+            className={isLarge ? "h-2" : undefined}
+          />
+          <span className={`w-12 text-right ${isLarge ? "text-base" : "text-sm"}`}>{bpm}</span>
         </div>
       </div>
 
@@ -45,9 +80,11 @@ export default function Transport({
           step={0.01}
           value={Math.min(position, duration)}
           onChange={(e) => onSeek(parseFloat(e.target.value))}
-          className="w-full"
+          className={`w-full ${sliderClass}`.trim()}
         />
-        <span className="text-xs tabular-nums">{position.toFixed(1)} / {duration.toFixed(1)}s</span>
+        <span className={`${isLarge ? "text-sm" : "text-xs"} tabular-nums`}>
+          {position.toFixed(1)} / {duration.toFixed(1)}s
+        </span>
       </div>
     </div>
   );

--- a/components/experience/ContributionControls.tsx
+++ b/components/experience/ContributionControls.tsx
@@ -17,6 +17,7 @@ type Props = {
   loading: boolean;
   error: string | null;
   onUpload: (grid: Grid) => void;
+  variant?: "default" | "touch";
 };
 
 export function ContributionControls({
@@ -32,16 +33,32 @@ export function ContributionControls({
   loading,
   error,
   onUpload,
+  variant = "default",
 }: Props) {
+  const isTouch = variant === "touch";
+  const tabButtonBase = isTouch
+    ? "px-4 py-2 text-base"
+    : "px-3 py-1 text-sm sm:text-base";
+  const tabActiveClass = "bg-blue-600";
+  const tabIdleClass = isTouch
+    ? "bg-neutral-800 hover:bg-neutral-700"
+    : "bg-neutral-800 hover:bg-neutral-700";
+  const sectionPadding = isTouch ? "p-4" : "p-3";
+  const labelClass = isTouch ? "text-sm font-medium" : "text-xs opacity-70";
+  const inputClass = isTouch
+    ? "w-full rounded border border-neutral-800 bg-neutral-900 px-3 py-3 text-base"
+    : "w-full rounded border border-neutral-800 bg-neutral-900 px-3 py-2";
+  const loadButtonClass = isTouch
+    ? "px-4 py-3 text-base"
+    : "px-3 py-2";
+
   return (
     <div className="flex flex-col gap-3">
       <div className="flex items-center gap-2 flex-wrap">
         <button
           type="button"
-          className={`px-3 py-1 rounded ${
-            tab === "github"
-              ? "bg-blue-600"
-              : "bg-neutral-800 hover:bg-neutral-700"
+          className={`${tabButtonBase} rounded ${
+            tab === "github" ? tabActiveClass : tabIdleClass
           }`}
           onClick={() => onTabChange("github")}
         >
@@ -49,10 +66,8 @@ export function ContributionControls({
         </button>
         <button
           type="button"
-          className={`px-3 py-1 rounded ${
-            tab === "upload"
-              ? "bg-blue-600"
-              : "bg-neutral-800 hover:bg-neutral-700"
+          className={`${tabButtonBase} rounded ${
+            tab === "upload" ? tabActiveClass : tabIdleClass
           }`}
           onClick={() => onTabChange("upload")}
         >
@@ -61,31 +76,33 @@ export function ContributionControls({
       </div>
 
       {tab === "github" && (
-        <section className="flex flex-col gap-3 p-3 border border-neutral-800 rounded-md">
+        <section
+          className={`flex flex-col gap-3 border border-neutral-800 rounded-md ${sectionPadding}`}
+        >
           <div className="grid grid-cols-1 sm:grid-cols-4 gap-3">
             <div className="col-span-2">
-              <label className="text-xs opacity-70">GitHub username</label>
+              <label className={labelClass}>GitHub username</label>
               <input
-                className="w-full px-3 py-2 rounded bg-neutral-900 border border-neutral-800"
+                className={inputClass}
                 value={username}
                 onChange={(e) => onUsernameChange(e.target.value)}
                 placeholder="octocat"
               />
             </div>
             <div>
-              <label className="text-xs opacity-70">From</label>
+              <label className={labelClass}>From</label>
               <input
                 type="date"
-                className="w-full px-3 py-2 rounded bg-neutral-900 border border-neutral-800"
+                className={inputClass}
                 value={from}
                 onChange={(e) => onFromChange(e.target.value)}
               />
             </div>
             <div>
-              <label className="text-xs opacity-70">To</label>
+              <label className={labelClass}>To</label>
               <input
                 type="date"
-                className="w-full px-3 py-2 rounded bg-neutral-900 border border-neutral-800"
+                className={inputClass}
                 value={to}
                 onChange={(e) => onToChange(e.target.value)}
               />
@@ -94,13 +111,17 @@ export function ContributionControls({
           <div className="flex gap-2 items-center">
             <button
               type="button"
-              className="px-3 py-2 rounded bg-blue-600 hover:bg-blue-500 disabled:opacity-60"
+              className={`${loadButtonClass} rounded bg-blue-600 hover:bg-blue-500 disabled:opacity-60`}
               onClick={onLoadGithub}
               disabled={loading}
             >
               {loading ? "Loading…" : "Load contributions"}
             </button>
-            {error && <span className="text-red-400 text-sm">{error}</span>}
+            {error && (
+              <span className={`text-red-400 ${isTouch ? "text-base" : "text-sm"}`}>
+                {error}
+              </span>
+            )}
           </div>
         </section>
       )}

--- a/hooks/useMedia.ts
+++ b/hooks/useMedia.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+type MediaState = {
+  isDesktop: boolean;
+  isTablet: boolean;
+  isMobile: boolean;
+  ready: boolean;
+};
+
+const DESKTOP_QUERY = "(min-width: 1024px)";
+const TABLET_QUERY = "(min-width: 640px) and (max-width: 1023px)";
+const MOBILE_QUERY = "(max-width: 639px)";
+
+function getMatches(): Omit<MediaState, "ready"> {
+  if (typeof window === "undefined") {
+    return {
+      isDesktop: false,
+      isTablet: false,
+      isMobile: false,
+    };
+  }
+
+  return {
+    isDesktop: window.matchMedia(DESKTOP_QUERY).matches,
+    isTablet: window.matchMedia(TABLET_QUERY).matches,
+    isMobile: window.matchMedia(MOBILE_QUERY).matches,
+  };
+}
+
+export function useMedia(): MediaState {
+  const [state, setState] = useState<MediaState>(() => ({
+    ...getMatches(),
+    ready: typeof window !== "undefined",
+  }));
+
+  const queries = useMemo(
+    () => [DESKTOP_QUERY, TABLET_QUERY, MOBILE_QUERY] as const,
+    []
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const mqls = queries.map((query) => window.matchMedia(query));
+
+    const update = () => {
+      setState({
+        ...getMatches(),
+        ready: true,
+      });
+    };
+
+    update();
+
+    mqls.forEach((mql) => mql.addEventListener("change", update));
+
+    return () => {
+      mqls.forEach((mql) => mql.removeEventListener("change", update));
+    };
+  }, [queries]);
+
+  return state;
+}

--- a/hooks/useMedia.ts
+++ b/hooks/useMedia.ts
@@ -30,10 +30,12 @@ function getMatches(): Omit<MediaState, "ready"> {
 }
 
 export function useMedia(): MediaState {
-  const [state, setState] = useState<MediaState>(() => ({
-    ...getMatches(),
-    ready: typeof window !== "undefined",
-  }));
+  const [state, setState] = useState<MediaState>({
+    isDesktop: false,
+    isTablet: false,
+    isMobile: false,
+    ready: false,
+  });
 
   const queries = useMemo(
     () => [DESKTOP_QUERY, TABLET_QUERY, MOBILE_QUERY] as const,

--- a/public/preview-light.svg
+++ b/public/preview-light.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">ContriSonics preview illustration</title>
+  <desc id="desc">Abstract representation of the ContriSonics interface with panels and waveform.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#18181b" />
+      <stop offset="100%" stop-color="#3f3f46" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="360" fill="url(#bg)" rx="24" />
+  <g opacity="0.9" transform="translate(60 60)">
+    <rect width="220" height="140" rx="18" fill="#18181b" stroke="#27272a" stroke-width="4" />
+    <rect x="28" y="32" width="164" height="28" rx="14" fill="#52525b" opacity="0.4" />
+    <rect x="28" y="76" width="112" height="20" rx="10" fill="#71717a" opacity="0.5" />
+    <rect x="28" y="106" width="74" height="20" rx="10" fill="#71717a" opacity="0.35" />
+  </g>
+  <g transform="translate(330 96)">
+    <polyline points="0,120 36,92 72,124 108,68 144,88 180,36 216,52" fill="none" stroke="#38bdf8" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" opacity="0.75" />
+    <polyline points="0,146 36,118 72,150 108,94 144,114 180,62 216,78" fill="none" stroke="#c084fc" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" opacity="0.45" />
+  </g>
+  <g transform="translate(60 230)" opacity="0.8">
+    <rect width="520" height="70" rx="16" fill="#18181b" stroke="#27272a" stroke-width="4" />
+    <rect x="28" y="20" width="120" height="30" rx="15" fill="#6366f1" opacity="0.65" />
+    <rect x="168" y="20" width="90" height="30" rx="15" fill="#22d3ee" opacity="0.55" />
+    <rect x="278" y="20" width="170" height="30" rx="15" fill="#f97316" opacity="0.45" />
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- replace the MobileFallback preview asset with a text-based SVG so the change no longer introduces a binary file
- point the MobileFallback component at the new SVG illustration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc96a2ffac83229f1a33da89ff762b