### PR TITLE
Add theme toggle and synchronized theming

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,12 @@ Open http://localhost:3000
 - `app/` Next.js App Router pages and API routes.
 - `components/` UI & 3D components.
 - `lib/` audio engine, mapping, and contributions fetch helpers.
+
+## Theme system
+
+- Light/Dark/System themes are managed by a lightweight `next-themes`-compatible provider (`lib/theme/next-themes.tsx`) which persists the user's choice to `localStorage` and defaults to the OS preference. A tiny inline script ensures the correct class is applied before hydration to avoid flashes.
+- Color tokens are defined once in `app/globals.css` via CSS custom properties (e.g. `--color-bg`, `--scene-bg`). Components reference these variables directly or through helper utility classes to stay in sync with the current theme.
+- The global `<ThemeToggle />` component (top-right on every layout, tablet, and mobile fallback view) lets users pick Light, Dark, or System modes and is fully keyboard accessible.
+- Three.js canvases consume the same variables through the `useSceneColors` hook so the 3D clear color and ground plane update instantly with the selected theme.
+- Key UI surfaces were refreshed for contrast in both themes, including `InstrumentSelect`, `ContributionControls`, `Transport`, `Grid2D`, `HeatmapTooltip`, `LiteApp`, `MobileFallback`, and `Uploader`.
+- To add new themed components, prefer the existing CSS variables or the helper classes defined in `globals.css`. Access the current theme in React via `useTheme()` and the resolved scene colors via `useSceneColors()` when working with WebGL content.

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,13 +3,104 @@
 @tailwind utilities;
 
 :root {
-  color-scheme: dark;
+  color-scheme: light;
+  --color-bg: #f7f9fb;
+  --color-surface: #ffffff;
+  --color-surface-muted: #e8edf6;
+  --color-surface-elevated: rgba(255, 255, 255, 0.7);
+  --color-border: rgba(15, 23, 42, 0.12);
+  --color-border-strong: rgba(15, 23, 42, 0.24);
+  --color-text: #0f172a;
+  --color-text-muted: rgba(15, 23, 42, 0.66);
+  --color-accent: #2563eb;
+  --color-accent-foreground: #eff6ff;
+  --color-focus-ring: #2563eb;
+  --color-button: rgba(15, 23, 42, 0.08);
+  --color-button-hover: rgba(15, 23, 42, 0.16);
+  --color-tooltip-bg: rgba(15, 23, 42, 0.92);
+  --color-tooltip-text: #f8fafc;
+  --scene-bg: #f7f9fb;
+  --scene-grid: #d9e2f1;
 }
 
-html, body, #__next {
-  height: 100%;
+.dark {
+  color-scheme: dark;
+  --color-bg: #05070b;
+  --color-surface: rgba(15, 23, 42, 0.9);
+  --color-surface-muted: rgba(30, 41, 59, 0.72);
+  --color-surface-elevated: rgba(15, 23, 42, 0.72);
+  --color-border: rgba(148, 163, 184, 0.24);
+  --color-border-strong: rgba(148, 163, 184, 0.38);
+  --color-text: #e2e8f0;
+  --color-text-muted: rgba(148, 163, 184, 0.85);
+  --color-accent: #38bdf8;
+  --color-accent-foreground: #082f49;
+  --color-focus-ring: #38bdf8;
+  --color-button: rgba(148, 163, 184, 0.16);
+  --color-button-hover: rgba(148, 163, 184, 0.26);
+  --color-tooltip-bg: rgba(15, 23, 42, 0.92);
+  --color-tooltip-text: #e2e8f0;
+  --scene-bg: #0b0f15;
+  --scene-grid: #111827;
+}
+
+html,
+body {
+  min-height: 100%;
 }
 
 body {
-  @apply bg-neutral-950 text-neutral-100;
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  font-feature-settings: 'liga' 1, 'clig' 1;
+}
+
+::selection {
+  background: var(--color-accent);
+  color: var(--color-accent-foreground);
+}
+
+@layer components {
+  .text-muted {
+    color: var(--color-text-muted);
+  }
+
+  .surface-card {
+    background-color: var(--color-surface);
+  }
+
+  .surface-muted {
+    background-color: var(--color-surface-muted);
+  }
+
+  .surface-elevated {
+    background-color: var(--color-surface-elevated);
+    backdrop-filter: blur(12px);
+  }
+
+  .border-subtle {
+    border-color: var(--color-border);
+  }
+
+  .border-strong {
+    border-color: var(--color-border-strong);
+  }
+
+  .btn-muted {
+    background-color: var(--color-button);
+    color: inherit;
+  }
+
+  .btn-muted:hover {
+    background-color: var(--color-button-hover);
+  }
+
+  .focus-ring {
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+  }
+
+  .focus-ring:focus-visible {
+    outline-color: var(--color-focus-ring);
+  }
 }

--- a/app/heatmap/page.tsx
+++ b/app/heatmap/page.tsx
@@ -8,6 +8,7 @@ import { ContributionControls } from "@/components/experience/ContributionContro
 import Transport from "@/components/Transport";
 import { Grid2D } from "@/components/Grid2D";
 import { useContributionExperience } from "@/components/experience/useContributionExperience";
+import { ThemeToggle } from "@/components/ThemeToggle";
 
 const GITHUB_PALETTE = [
   "#161b22",
@@ -50,23 +51,24 @@ export default function HeatmapPage() {
     <>
       <PointerTracker />
       <HeatmapTooltip />
-      <main className="min-h-screen bg-neutral-950 text-white">
-        <div className="max-w-6xl mx-auto p-4 flex flex-col gap-6">
-          <header className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3">
+      <main className="min-h-screen bg-[var(--color-bg)] text-[var(--color-text)]">
+        <div className="mx-auto flex max-w-6xl flex-col gap-6 p-4">
+          <header className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
             <div className="space-y-1">
               <h1 className="text-2xl font-semibold">GitHub 2D Heatmap</h1>
-              <p className="opacity-70 text-sm">
+              <p className="text-sm text-muted">
                 Explore a flat contribution grid with the same musical controls and data sources as the 3D view.
               </p>
             </div>
-            <div className="flex items-center gap-2 flex-wrap">
+            <div className="flex flex-wrap items-center gap-2 sm:justify-end">
               <InstrumentSelect value={instrument} onChange={changeInstrument} />
               <Link
                 href="/"
-                className="px-3 py-1 rounded bg-neutral-800 hover:bg-neutral-700"
+                className="rounded-full bg-[var(--color-button)] px-3 py-1 text-sm font-medium transition hover:bg-[var(--color-button-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)]"
               >
                 ← Back to 3D experience
               </Link>
+              <ThemeToggle />
             </div>
           </header>
 
@@ -85,14 +87,14 @@ export default function HeatmapPage() {
             onUpload={handleUploadGrid}
           />
 
-          <section className="rounded-md border border-neutral-800 bg-neutral-900/40">
+          <section className="rounded-md border border-subtle surface-elevated">
             <Grid2D grid={grid} onHoverNote={previewCell} activeCell={activeCell} />
-            <div className="flex items-center gap-2 px-4 pb-4 text-xs text-neutral-400">
+            <div className="flex items-center gap-2 px-4 pb-4 text-xs text-muted">
               <span>Less</span>
               {GITHUB_PALETTE.map((color) => (
                 <span
                   key={color}
-                  className="h-3 w-3 rounded-sm border border-neutral-800"
+                  className="h-3 w-3 rounded-sm border border-subtle"
                   style={{ backgroundColor: color }}
                   aria-hidden
                 />
@@ -113,7 +115,7 @@ export default function HeatmapPage() {
             onBpmChange={setBpm}
           />
 
-          <footer className="opacity-60 text-xs">
+          <footer className="text-xs text-muted">
             Built with Next.js, Tailwind CSS, and the Web Audio API. © Natsuki.
           </footer>
         </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,7 @@
 import './globals.css';
 import React from 'react';
+import { ThemeProvider } from 'next-themes';
+import { ThemeScript } from '@/components/theme/ThemeScript';
 
 export const metadata = {
   title: 'ContriSonics',
@@ -8,8 +10,11 @@ export const metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
-      <body>{children}</body>
+    <html lang="en" suppressHydrationWarning>
+      <body className="min-h-screen bg-[var(--color-bg)] text-[var(--color-text)] antialiased">
+        <ThemeScript />
+        <ThemeProvider defaultTheme="system">{children}</ThemeProvider>
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,6 +12,7 @@ import { ContributionControls } from "@/components/experience/ContributionContro
 import { LiteApp } from "@/components/LiteApp";
 import { MobileFallback } from "@/components/MobileFallback";
 import { useMedia } from "@/hooks/useMedia";
+import { ThemeToggle } from "@/components/ThemeToggle";
 
 function DesktopApp() {
   const {
@@ -45,20 +46,21 @@ function DesktopApp() {
     <>
       <PointerTracker />
       <HeatmapTooltip />
-      <main className="mx-auto flex max-w-6xl flex-col gap-4 p-4">
+      <main className="mx-auto flex max-w-6xl flex-col gap-4 p-4 text-[var(--color-text)]">
         <header className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <h1 className="text-2xl font-semibold">ContriSonics</h1>
-            <p className="text-sm opacity-70">3D GitHub contributions → music.</p>
+            <p className="text-sm text-muted">3D GitHub contributions → music.</p>
           </div>
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2 sm:justify-end">
             <InstrumentSelect value={instrument} onChange={changeInstrument} />
             <Link
               href="/heatmap"
-              className="rounded bg-neutral-800 px-3 py-1 hover:bg-neutral-700"
+              className="rounded-full bg-[var(--color-button)] px-3 py-1 text-sm font-medium transition hover:bg-[var(--color-button-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)]"
             >
               2D Heatmap
             </Link>
+            <ThemeToggle />
           </div>
         </header>
 
@@ -77,13 +79,13 @@ function DesktopApp() {
           onUpload={handleUploadGrid}
         />
 
-        <section className="overflow-hidden rounded-md border border-neutral-800">
+        <section className="overflow-hidden rounded-md border border-subtle surface-elevated">
           {grid ? (
             <div className="mx-auto w-[min(1200px,95vw)] aspect-[16/9]">
               <GridScene grid={grid} onHoverNote={previewCell} />
             </div>
           ) : (
-            <div className="p-6 opacity-70">No grid loaded yet.</div>
+            <div className="p-6 text-muted">No grid loaded yet.</div>
           )}
         </section>
 
@@ -99,7 +101,7 @@ function DesktopApp() {
           onBpmChange={setBpm}
         />
 
-        <footer className="text-xs opacity-60">
+        <footer className="text-xs text-muted">
           Built with Next.js, react-three-fiber, and the Web Audio API. © Natsuki.
         </footer>
       </main>
@@ -112,7 +114,7 @@ export default function Page() {
 
   if (!media.ready) {
     return (
-      <main className="flex min-h-screen items-center justify-center bg-neutral-950 text-neutral-300">
+      <main className="flex min-h-screen items-center justify-center bg-[var(--color-bg)] text-muted">
         Loading experience…
       </main>
     );

--- a/components/Grid2D.tsx
+++ b/components/Grid2D.tsx
@@ -26,7 +26,7 @@ export function Grid2D({ grid, onHoverNote, activeCell }: Props) {
   );
 
   if (!grid) {
-    return <div className="p-6 opacity-70">No grid loaded yet.</div>;
+    return <div className="p-6 text-muted">No grid loaded yet.</div>;
   }
 
   return (
@@ -42,10 +42,10 @@ export function Grid2D({ grid, onHoverNote, activeCell }: Props) {
         const isCurrent =
           activeCell?.row === cell.row && activeCell?.col === cell.col;
         const classes = [
-          "aspect-square rounded-sm border transition-transform focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
-          isActive ? "border-neutral-700" : "border-neutral-900",
+          "aspect-square rounded-sm border border-subtle transition-transform focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)]",
+          isActive ? "border-strong" : null,
           isCurrent
-            ? "ring-2 ring-emerald-400 ring-offset-2 ring-offset-neutral-900 scale-110 shadow-[0_0_12px_rgba(52,211,153,0.55)]"
+            ? "ring-2 ring-emerald-400 ring-offset-2 ring-offset-[var(--color-bg)] scale-110 shadow-[0_0_12px_rgba(52,211,153,0.45)]"
             : null,
         ]
           .filter(Boolean)

--- a/components/Grid3D.tsx
+++ b/components/Grid3D.tsx
@@ -3,8 +3,10 @@
 import React, { useEffect, useMemo } from 'react';
 import { Canvas, useThree } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
+import { Color } from 'three';
 import type { Grid, GridCell } from '@/lib/types';
 import { GridCell3D } from './GridCell3D';
+import { useSceneColors } from '@/hooks/useSceneColors';
 
 type Props = {
   grid: Grid | null;
@@ -12,6 +14,8 @@ type Props = {
 };
 
 export function GridScene({ grid, onHoverNote }: Props) {
+  const sceneColors = useSceneColors();
+
   const size = useMemo(() => ({
     w: (grid?.cols ?? 0) * 0.9,
     h: (grid?.rows ?? 0) * 0.9
@@ -28,13 +32,14 @@ export function GridScene({ grid, onHoverNote }: Props) {
         }
       }}
     >
+      <SceneColorController color={sceneColors.background} />
       <VisibilityController />
       <ambientLight intensity={0.6} />
       <directionalLight position={[5, 10, 5]} intensity={1.0} castShadow />
       <group position={[-size.w/2, 0, -size.h/2]}>
         <mesh rotation-x={-Math.PI/2} receiveShadow>
           <planeGeometry args={[Math.max(8, size.w+2), Math.max(8, size.h+2)]} />
-          <meshStandardMaterial color={'#111214'} />
+          <meshStandardMaterial color={sceneColors.plane} />
         </mesh>
         {grid?.cells.map((c, i) => (
           <GridCell3D key={i} cell={c} onHoverNote={onHoverNote} />
@@ -56,6 +61,18 @@ function VisibilityController() {
     document.addEventListener('visibilitychange', handle);
     return () => document.removeEventListener('visibilitychange', handle);
   }, [setFrameloop]);
+
+  return null;
+}
+
+function SceneColorController({ color }: { color: string }) {
+  const { gl, scene } = useThree();
+
+  useEffect(() => {
+    const resolved = new Color(color);
+    gl.setClearColor(resolved);
+    scene.background = resolved;
+  }, [color, gl, scene]);
 
   return null;
 }

--- a/components/HeatmapTooltip.tsx
+++ b/components/HeatmapTooltip.tsx
@@ -46,7 +46,7 @@ export function HeatmapTooltip() {
       role="tooltip"
       aria-hidden={false}
       style={{ position: 'fixed', left: pos.left, top: pos.top, pointerEvents: 'none', zIndex: 50 }}
-      className="rounded-md border border-neutral-700 bg-neutral-900/95 px-3 py-2 text-sm text-neutral-100 shadow-xl backdrop-blur"
+      className="rounded-md border border-subtle bg-[var(--color-tooltip-bg)] px-3 py-2 text-sm text-[var(--color-tooltip-text)] shadow-xl backdrop-blur"
     >
       {text}
     </div>,

--- a/components/InstrumentSelect.tsx
+++ b/components/InstrumentSelect.tsx
@@ -17,14 +17,14 @@ export function InstrumentSelect({ value, onChange, size = "md" }: Props) {
   ];
 
   const labelClass =
-    size === "lg" ? "text-base font-medium" : "text-sm opacity-80";
+    size === "lg" ? "text-base font-medium" : "text-xs text-muted";
   const selectClass =
     size === "lg"
-      ? "border rounded px-3 py-2 text-base bg-neutral-900"
-      : "border rounded px-2 py-1 bg-neutral-900";
+      ? "w-full min-w-[10rem] rounded-full border border-subtle bg-[var(--color-surface)] px-3 py-2 text-base text-[var(--color-text)] shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)]"
+      : "rounded-full border border-subtle bg-[var(--color-surface)] px-2 py-1 text-sm text-[var(--color-text)] shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)]";
 
   return (
-    <label className="flex items-center gap-2">
+    <label className="flex items-center gap-2 text-[var(--color-text)]">
       <span className={labelClass}>Instrument</span>
       <select
         className={selectClass}

--- a/components/LiteApp.tsx
+++ b/components/LiteApp.tsx
@@ -17,6 +17,8 @@ import Transport from "@/components/Transport";
 import { InstrumentSelect } from "@/components/InstrumentSelect";
 import type { Grid, GridCell } from "@/lib/types";
 import { formatContribution, formatDateLong } from "@/lib/format";
+import { ThemeToggle } from "@/components/ThemeToggle";
+import { useSceneColors } from "@/hooks/useSceneColors";
 
 export function LiteApp() {
   const {
@@ -79,21 +81,26 @@ export function LiteApp() {
     controlsRef.current?.update();
   };
 
+  const sceneColors = useSceneColors();
+
   return (
-    <div className="flex min-h-screen flex-col gap-6 bg-neutral-950 px-5 py-6 text-neutral-100">
-      <header className="space-y-2">
-        <h1 className="text-3xl font-semibold">ContriSonics Lite</h1>
-        <p className="text-base text-neutral-400">
-          Streamlined tablet mode with adaptive quality controls.
-        </p>
+    <div className="flex min-h-screen flex-col gap-6 bg-[var(--color-bg)] px-5 py-6 text-[var(--color-text)]">
+      <header className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-semibold">ContriSonics Lite</h1>
+          <p className="text-base text-muted">
+            Streamlined tablet mode with adaptive quality controls.
+          </p>
+        </div>
+        <ThemeToggle />
       </header>
 
       <div className="flex flex-col gap-5">
-        <div className="flex flex-wrap items-center justify-between gap-4 rounded-lg border border-neutral-800 bg-neutral-900/40 p-4">
+        <div className="flex flex-wrap items-center justify-between gap-4 rounded-lg border border-subtle surface-elevated p-4">
           <InstrumentSelect value={instrument} onChange={changeInstrument} size="lg" />
           <Link
             href="/heatmap"
-            className="rounded-full bg-blue-600 px-5 py-3 text-base font-semibold text-white hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-300"
+            className="rounded-full bg-[var(--color-accent)] px-5 py-3 text-base font-semibold text-[var(--color-accent-foreground)] transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)]"
           >
             Open 2D Heatmap
           </Link>
@@ -116,7 +123,7 @@ export function LiteApp() {
         />
 
         <div className="space-y-3">
-          <div className="mx-auto w-[min(1200px,95vw)] aspect-[16/9] overflow-hidden rounded-xl border border-neutral-800 bg-neutral-950/80">
+          <div className="mx-auto w-[min(1200px,95vw)] aspect-[16/9] overflow-hidden rounded-xl border border-subtle surface-elevated">
             {grid ? (
               <Canvas
                 camera={{ position: cameraPosition, fov: 55 }}
@@ -138,22 +145,24 @@ export function LiteApp() {
                   onSelectCell={handleSelectCell}
                   quality={quality}
                   controlsRef={controlsRef}
+                  background={sceneColors.background}
+                  planeColor={sceneColors.plane}
                 />
               </Canvas>
             ) : (
-              <div className="flex h-full items-center justify-center px-6 text-center text-neutral-500">
+              <div className="flex h-full items-center justify-center px-6 text-center text-muted">
                 Load a contribution grid to explore it in 3D.
               </div>
             )}
           </div>
 
-          <div className="text-center text-sm text-neutral-300">{activeSummary}</div>
+          <div className="text-center text-sm text-muted">{activeSummary}</div>
 
           <div className="flex justify-center">
             <button
               type="button"
               onClick={handleResetView}
-              className="rounded-full bg-neutral-200 px-6 py-3 text-base font-medium text-neutral-900 shadow focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+              className="rounded-full bg-[var(--color-button)] px-6 py-3 text-base font-medium text-[var(--color-text)] shadow-sm transition hover:bg-[var(--color-button-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)]"
             >
               Reset View
             </button>
@@ -174,7 +183,7 @@ export function LiteApp() {
         />
       </div>
 
-      <footer className="pt-6 text-sm text-neutral-500">
+      <footer className="pt-6 text-sm text-muted">
         Optimized for tablets. Switch to desktop for shadows and the full 3D treatment.
       </footer>
     </div>
@@ -186,11 +195,15 @@ function LiteScene({
   onSelectCell,
   quality,
   controlsRef,
+  background,
+  planeColor,
 }: {
   grid: Grid;
   onSelectCell: (cell: GridCell) => void;
   quality: "high" | "low";
   controlsRef: React.RefObject<OrbitControlsImpl>;
+  background: string;
+  planeColor: string;
 }) {
   const spacing = quality === "high" ? 0.82 : 0.95;
   const heightScale = quality === "high" ? 0.32 : 0.24;
@@ -205,13 +218,13 @@ function LiteScene({
 
   return (
     <group>
-      <color attach="background" args={["#050506"]} />
+      <color attach="background" args={[background]} />
       <hemisphereLight args={["#f8fafc", "#0f172a", 0.85]} />
       <directionalLight position={[10, 12, 6]} intensity={0.65} />
       <group position={[offset.x, 0, offset.z]}>
         <mesh rotation-x={-Math.PI / 2}>
           <planeGeometry args={[Math.max(12, cols * spacing + 4), Math.max(12, rows * spacing + 4)]} />
-          <meshStandardMaterial color="#111217" />
+          <meshStandardMaterial color={planeColor} />
         </mesh>
         {grid.cells.map((cell) => (
           <LiteColumn

--- a/components/MobileFallback.tsx
+++ b/components/MobileFallback.tsx
@@ -1,27 +1,29 @@
 "use client";
 
 import Image from "next/image";
+import { ThemeToggle } from "@/components/ThemeToggle";
 
 export function MobileFallback() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-neutral-950 px-6 py-10 text-center text-neutral-100">
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-[var(--color-bg)] px-6 py-10 text-center text-[var(--color-text)]">
+      <ThemeToggle className="self-end" />
       <div className="max-w-md space-y-4">
         <h1 className="text-2xl font-semibold">ContriSonics</h1>
-        <p className="text-base leading-relaxed text-neutral-300">
+        <p className="text-base leading-relaxed text-muted">
           This demo is optimized for larger screens. For the full 3D experience, please open on a desktop.
         </p>
       </div>
-      <div className="relative h-48 w-80 overflow-hidden rounded-xl border border-neutral-800 bg-neutral-900">
+      <div className="relative h-48 w-80 overflow-hidden rounded-xl border border-subtle surface-elevated">
         <Image
           src="/preview-light.svg"
           alt="Preview of the ContriSonics 3D scene"
           fill
-          className="object-cover opacity-80"
+          className="object-cover opacity-90"
           sizes="320px"
           priority
         />
       </div>
-      <p className="text-sm text-neutral-500">
+      <p className="text-sm text-muted">
         Tip: rotate your device or visit again on a tablet/desktop for an interactive mode.
       </p>
     </main>

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useTheme } from "next-themes";
+
+type Option = {
+  value: "light" | "dark" | "system";
+  label: string;
+  icon: ReactNode;
+};
+
+function SunIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" className={className}>
+      <path
+        fill="currentColor"
+        d="M12 5.25a1 1 0 0 1-1-1V2.5a1 1 0 0 1 2 0v1.75a1 1 0 0 1-1 1Zm0 16.25a1 1 0 0 1-1 1v-1.75a1 1 0 1 1 2 0V22.5a1 1 0 0 1-1 1Zm10-9.5a1 1 0 0 1-1 1h-1.75a1 1 0 0 1 0-2H21a1 1 0 0 1 1 1ZM5.75 12a1 1 0 0 1-1 1H3a1 1 0 0 1 0-2h1.75a1 1 0 0 1 1 1Zm13.45 6.45a1 1 0 0 1 0 1.41l-1.24 1.25a1 1 0 0 1-1.42-1.41l1.25-1.25a1 1 0 0 1 1.41 0ZM7.46 6.54a1 1 0 0 1 0 1.41L6.22 9.2A1 1 0 0 1 4.8 7.78L6.05 6.53a1 1 0 0 1 1.41 0Zm11 1.24a1 1 0 0 1-1.42-1.41l1.25-1.25a1 1 0 1 1 1.41 1.41Zm-11 9.92a1 1 0 0 1 1.42 0l1.24 1.25a1 1 0 1 1-1.41 1.41L7.46 19.1a1 1 0 0 1 0-1.41ZM12 7a5 5 0 1 1 0 10 5 5 0 0 1 0-10Z"
+      />
+    </svg>
+  );
+}
+
+function MoonIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" className={className}>
+      <path
+        fill="currentColor"
+        d="M20.5 13.43A8.5 8.5 0 0 1 10.57 3.5a.5.5 0 0 0-.53-.68A8.5 8.5 0 1 0 21.18 14a.5.5 0 0 0-.68-.57Z"
+      />
+    </svg>
+  );
+}
+
+function SystemIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" className={className}>
+      <path
+        fill="currentColor"
+        d="M4 5.5A2.5 2.5 0 0 1 6.5 3h11A2.5 2.5 0 0 1 20 5.5v9A2.5 2.5 0 0 1 17.5 17H6.5A2.5 2.5 0 0 1 4 14.5Zm2.5-1a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h11a1 1 0 0 0 1-1v-9a1 1 0 0 0-1-1ZM5 19.5a1 1 0 0 1 1-1h12a1 1 0 1 1 0 2H6a1 1 0 0 1-1-1Z"
+      />
+    </svg>
+  );
+}
+
+function clsx(...values: Array<string | false | null | undefined>) {
+  return values.filter(Boolean).join(" ");
+}
+
+export function ThemeToggle({ className }: { className?: string }) {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const options: Option[] = useMemo(
+    () => [
+      { value: "light", label: "Light", icon: <SunIcon className="h-4 w-4" /> },
+      { value: "dark", label: "Dark", icon: <MoonIcon className="h-4 w-4" /> },
+      { value: "system", label: "System", icon: <SystemIcon className="h-4 w-4" /> },
+    ],
+    []
+  );
+
+  const activeValue = mounted ? theme ?? "system" : "system";
+
+  return (
+    <div
+      className={clsx(
+        "flex items-center gap-1 rounded-full border border-subtle bg-[var(--color-surface-elevated)] px-1 py-1 text-xs shadow-sm backdrop-blur",
+        className
+      )}
+      role="group"
+      aria-label="Toggle theme"
+    >
+      {options.map((option) => {
+        const isActive = activeValue === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            className={clsx(
+              "flex items-center gap-1 rounded-full px-2 py-1 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2",
+              "focus-visible:outline-[var(--color-focus-ring)]",
+              isActive
+                ? "bg-[var(--color-button-hover)] text-[var(--color-text)] shadow-sm"
+                : "text-muted hover:bg-[var(--color-button)]"
+            )}
+            aria-pressed={isActive}
+            aria-label={option.label}
+            onClick={() => setTheme(option.value)}
+          >
+            {option.icon}
+            <span className="hidden sm:inline">{option.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export default ThemeToggle;

--- a/components/Transport.tsx
+++ b/components/Transport.tsx
@@ -31,18 +31,18 @@ export default function Transport({
 }: Props) {
   const isLarge = size === "lg";
   const gapClass = isLarge ? "gap-3" : "gap-2";
-  const paddingClass = isLarge ? "p-3" : "p-2";
-  const containerClasses = `flex flex-col ${gapClass} ${paddingClass} bg-neutral-900/60 rounded-md ${
+  const paddingClass = isLarge ? "p-4" : "p-3";
+  const containerClasses = `flex flex-col ${gapClass} ${paddingClass} rounded-lg border border-subtle surface-elevated shadow-sm ${
     className ?? ""
   }`;
   const buttonBase = isLarge
-    ? "rounded bg-neutral-800 hover:bg-neutral-700 px-4 py-2 text-base"
-    : "rounded bg-neutral-800 hover:bg-neutral-700 px-3 py-1";
+    ? "rounded-full px-4 py-2 text-base font-medium btn-muted transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)]"
+    : "rounded-full px-3 py-1.5 text-sm font-medium btn-muted transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)]";
   const primaryButton = isLarge
-    ? "rounded bg-blue-600 hover:bg-blue-500 px-5 py-2 text-base"
-    : "rounded bg-blue-600 hover:bg-blue-500 px-4 py-1";
+    ? "rounded-full bg-[var(--color-accent)] px-5 py-2 text-base font-semibold text-[var(--color-accent-foreground)] transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)]"
+    : "rounded-full bg-[var(--color-accent)] px-4 py-1.5 text-sm font-semibold text-[var(--color-accent-foreground)] transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)]";
   const sliderClass = isLarge ? "h-2" : "";
-  const bpmLabel = isLarge ? "text-sm" : "text-sm opacity-80";
+  const bpmLabel = isLarge ? "text-sm font-medium" : "text-xs text-muted";
   const bpmWrapper = isLarge ? "ml-0 sm:ml-4 gap-3" : "ml-4 gap-2";
 
   return (

--- a/components/Uploader.tsx
+++ b/components/Uploader.tsx
@@ -97,7 +97,7 @@ export default function Uploader({ onGridLoaded }: Props) {
   };
 
   return (
-    <div className="p-3 border border-neutral-800 rounded-md">
+    <div className="rounded-md border border-subtle surface-elevated p-3">
       <div className="flex items-center gap-3">
         <input
           type="file"
@@ -112,14 +112,14 @@ export default function Uploader({ onGridLoaded }: Props) {
           }}
         />
         <button
-          className="px-3 py-2 rounded bg-neutral-800 hover:bg-neutral-700"
+          className="rounded-full bg-[var(--color-accent)] px-3 py-2 text-sm font-medium text-[var(--color-accent-foreground)] transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)]"
           onClick={() => ref.current?.click()}
         >
           Upload GitHub screenshot
         </button>
-        <span className="opacity-70 text-sm">{name}</span>
+        <span className="text-sm text-muted">{name}</span>
       </div>
-      <p className="text-xs opacity-70 mt-2">
+      <p className="mt-2 text-xs text-muted">
         Parsing is naive and expects a raw GitHub contribution grid screenshot.
       </p>
     </div>

--- a/components/experience/ContributionControls.tsx
+++ b/components/experience/ContributionControls.tsx
@@ -37,27 +37,28 @@ export function ContributionControls({
 }: Props) {
   const isTouch = variant === "touch";
   const tabButtonBase = isTouch
-    ? "px-4 py-2 text-base"
-    : "px-3 py-1 text-sm sm:text-base";
-  const tabActiveClass = "bg-blue-600";
+    ? "px-4 py-2 text-base font-medium"
+    : "px-3 py-1 text-sm font-medium sm:text-base";
+  const tabActiveClass =
+    "bg-[var(--color-accent)] text-[var(--color-accent-foreground)] shadow-sm";
   const tabIdleClass = isTouch
-    ? "bg-neutral-800 hover:bg-neutral-700"
-    : "bg-neutral-800 hover:bg-neutral-700";
+    ? "btn-muted hover:bg-[var(--color-button-hover)]"
+    : "btn-muted hover:bg-[var(--color-button-hover)]";
   const sectionPadding = isTouch ? "p-4" : "p-3";
-  const labelClass = isTouch ? "text-sm font-medium" : "text-xs opacity-70";
+  const labelClass = isTouch ? "text-sm font-medium" : "text-xs text-muted";
   const inputClass = isTouch
-    ? "w-full rounded border border-neutral-800 bg-neutral-900 px-3 py-3 text-base"
-    : "w-full rounded border border-neutral-800 bg-neutral-900 px-3 py-2";
+    ? "w-full rounded-md border border-subtle bg-[var(--color-surface)] px-3 py-3 text-base text-[var(--color-text)] shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)]"
+    : "w-full rounded-md border border-subtle bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text)] shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)]";
   const loadButtonClass = isTouch
-    ? "px-4 py-3 text-base"
-    : "px-3 py-2";
+    ? "px-4 py-3 text-base font-medium"
+    : "px-3 py-2 text-sm font-medium";
 
   return (
     <div className="flex flex-col gap-3">
       <div className="flex items-center gap-2 flex-wrap">
         <button
           type="button"
-          className={`${tabButtonBase} rounded ${
+          className={`${tabButtonBase} rounded-full transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)] ${
             tab === "github" ? tabActiveClass : tabIdleClass
           }`}
           onClick={() => onTabChange("github")}
@@ -66,7 +67,7 @@ export function ContributionControls({
         </button>
         <button
           type="button"
-          className={`${tabButtonBase} rounded ${
+          className={`${tabButtonBase} rounded-full transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)] ${
             tab === "upload" ? tabActiveClass : tabIdleClass
           }`}
           onClick={() => onTabChange("upload")}
@@ -77,7 +78,7 @@ export function ContributionControls({
 
       {tab === "github" && (
         <section
-          className={`flex flex-col gap-3 border border-neutral-800 rounded-md ${sectionPadding}`}
+          className={`flex flex-col gap-3 rounded-md border border-subtle surface-elevated ${sectionPadding}`}
         >
           <div className="grid grid-cols-1 sm:grid-cols-4 gap-3">
             <div className="col-span-2">
@@ -111,14 +112,14 @@ export function ContributionControls({
           <div className="flex gap-2 items-center">
             <button
               type="button"
-              className={`${loadButtonClass} rounded bg-blue-600 hover:bg-blue-500 disabled:opacity-60`}
+              className={`${loadButtonClass} rounded-full bg-[var(--color-accent)] text-[var(--color-accent-foreground)] transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)] disabled:opacity-60`}
               onClick={onLoadGithub}
               disabled={loading}
             >
               {loading ? "Loading…" : "Load contributions"}
             </button>
             {error && (
-              <span className={`text-red-400 ${isTouch ? "text-base" : "text-sm"}`}>
+              <span className={`text-rose-400 ${isTouch ? "text-base" : "text-sm"}`}>
                 {error}
               </span>
             )}

--- a/components/theme/ThemeScript.tsx
+++ b/components/theme/ThemeScript.tsx
@@ -1,0 +1,27 @@
+const THEME_STORAGE_KEY = "contrisonics-theme";
+
+export function ThemeScript() {
+  const code = `(() => {
+  try {
+    const stored = window.localStorage.getItem('${THEME_STORAGE_KEY}');
+    const isValid = stored === 'light' || stored === 'dark' || stored === 'system';
+    const theme = isValid ? stored : 'system';
+    const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const resolved = theme === 'system' ? systemPrefersDark : theme;
+    const root = document.documentElement;
+    if (resolved === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    root.dataset.theme = resolved;
+    try { root.style.colorScheme = resolved; } catch (error) { /* noop */ }
+  } catch (error) {
+    // ignore
+  }
+})();`;
+
+  return <script dangerouslySetInnerHTML={{ __html: code }} suppressHydrationWarning />;
+}
+
+export default ThemeScript;

--- a/hooks/useSceneColors.ts
+++ b/hooks/useSceneColors.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+
+type SceneColors = {
+  background: string;
+  plane: string;
+};
+
+const LIGHT_FALLBACK: SceneColors = {
+  background: "#f7f9fb",
+  plane: "#d9e2f1",
+};
+
+const DARK_FALLBACK: SceneColors = {
+  background: "#0b0f15",
+  plane: "#111214",
+};
+
+export function useSceneColors(): SceneColors {
+  const { resolvedTheme } = useTheme();
+  const [colors, setColors] = useState<SceneColors>(
+    resolvedTheme === "dark" ? DARK_FALLBACK : LIGHT_FALLBACK
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const styles = getComputedStyle(document.documentElement);
+    const background = styles.getPropertyValue("--scene-bg").trim();
+    const plane = styles.getPropertyValue("--scene-grid").trim();
+    const fallback = resolvedTheme === "dark" ? DARK_FALLBACK : LIGHT_FALLBACK;
+    setColors({
+      background: background || fallback.background,
+      plane: plane || fallback.plane,
+    });
+  }, [resolvedTheme]);
+
+  return colors;
+}

--- a/lib/theme/next-themes.tsx
+++ b/lib/theme/next-themes.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+type Theme = "light" | "dark" | "system";
+type ResolvedTheme = "light" | "dark";
+
+type ThemeContextValue = {
+  theme: Theme;
+  resolvedTheme: ResolvedTheme;
+  systemTheme: ResolvedTheme;
+  setTheme: (theme: Theme) => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+const STORAGE_KEY = "contrisonics-theme";
+const themes: Theme[] = ["light", "dark", "system"];
+
+function getSystemTheme(): ResolvedTheme {
+  if (typeof window === "undefined") return "light";
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function isValidTheme(value: string | null): value is Theme {
+  return value === "light" || value === "dark" || value === "system";
+}
+
+function applyThemeClass(theme: ResolvedTheme) {
+  if (typeof document === "undefined") return;
+  const root = document.documentElement;
+  root.classList.toggle("dark", theme === "dark");
+  root.dataset.theme = theme;
+  try {
+    root.style.colorScheme = theme;
+  } catch (error) {
+    /* noop */
+  }
+}
+
+export type ThemeProviderProps = {
+  children: React.ReactNode;
+  defaultTheme?: Theme;
+};
+
+export function ThemeProvider({ children, defaultTheme = "system" }: ThemeProviderProps) {
+  const [theme, setThemeState] = useState<Theme>(defaultTheme);
+  const [systemTheme, setSystemTheme] = useState<ResolvedTheme>(getSystemTheme);
+  const resolvedTheme: ResolvedTheme = theme === "system" ? systemTheme : theme;
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      const stored = isValidTheme(raw) ? raw : null;
+      if (stored) {
+        setThemeState(stored);
+      } else {
+        setThemeState(defaultTheme);
+      }
+    } catch (error) {
+      setThemeState(defaultTheme);
+    }
+  }, [defaultTheme]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mql = window.matchMedia("(prefers-color-scheme: dark)");
+    const updateSystemTheme = (event: MediaQueryListEvent | MediaQueryList) => {
+      setSystemTheme(event.matches ? "dark" : "light");
+    };
+    updateSystemTheme(mql);
+
+    if ("addEventListener" in mql) {
+      const listener = updateSystemTheme as (event: MediaQueryListEvent) => void;
+      mql.addEventListener("change", listener);
+      return () => mql.removeEventListener("change", listener);
+    }
+
+    const legacyListener = updateSystemTheme as (event: MediaQueryList | MediaQueryListEvent) => void;
+    mql.addListener(legacyListener);
+    return () => mql.removeListener(legacyListener);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    applyThemeClass(resolvedTheme);
+  }, [resolvedTheme]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      if (theme === "system") {
+        localStorage.setItem(STORAGE_KEY, "system");
+      } else {
+        localStorage.setItem(STORAGE_KEY, theme);
+      }
+    } catch (error) {
+      // ignored
+    }
+  }, [theme]);
+
+  const setTheme = useCallback((value: Theme) => {
+    setThemeState(value);
+  }, []);
+
+  const value = useMemo(
+    () => ({ theme, resolvedTheme, systemTheme, setTheme }),
+    [theme, resolvedTheme, systemTheme, setTheme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return {
+    theme: context.theme,
+    resolvedTheme: context.resolvedTheme,
+    systemTheme: context.systemTheme,
+    setTheme: context.setTheme,
+    themes,
+  };
+}
+
+export { themes };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,10 @@
     ],
     "types": ["node", "react", "react-dom"],
     "baseUrl": ".",
-    "paths": { "@/*": ["./*"] }
+    "paths": {
+      "@/*": ["./*"],
+      "next-themes": ["./lib/theme/next-themes"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- introduce a lightweight next-themes compatible provider, theme bootstrap script, and shared CSS variables for light/dark/system modes
- add an accessible ThemeToggle component and wire it into desktop, heatmap, tablet, and mobile views while refreshing control styling for contrast
- sync three.js scenes with CSS variables through a reusable hook so the canvas background and ground plane react to theme changes
- document the theme system and the components refreshed for contrast in the README

## Testing
- `npm run lint` *(fails locally: Next.js binary unavailable because npm install is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dca3db52848322808afcc86b038fc8